### PR TITLE
Subscribe to newsletter at the bottom of each blog post

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,8 @@
 const React = require('react');
 const fs = require('fs');
+const map = require('lodash/map');
 
-const { FORM_NAME } = require('./src/contactFormConstants');
+const { FORM_NAMES } = require('./src/contactFormConstants');
 
 const HEAD_CSS = fs.readFileSync('src/head-loaded-styles.css').toString();
 
@@ -9,16 +10,16 @@ const HEAD_CSS = fs.readFileSync('src/head-loaded-styles.css').toString();
 // for this website. If I put the tags on the form which actually performs the submission
 // then it doesn't work. I believe that form is rendered too dynamically to trigger the netlify
 // bot. This form doesn't do any actual work on the site for users.
-const embeddedForm = (
-  <form name={FORM_NAME} netlify="true" netlify-honeypot="bot-field" hidden key="form">
+const embeddedForms = map(FORM_NAMES, (value) => (
+  <form name={value} netlify="true" netlify-honeypot="bot-field" hidden key="form">
     <input type="email" name="email" />
   </form>
-);
+));
 
 exports.onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   // Getting these into the head so the fonts start loading fast and we don't have a FoUC.
   // Have to use dangerouslySetInnerHTML to prevent escaping of quotation marks in the CSS.
   setHeadComponents([<style key="inline-styles" dangerouslySetInnerHTML={{ __html: HEAD_CSS }} />]);
 
-  setPostBodyComponents([embeddedForm]);
+  setPostBodyComponents(embeddedForms);
 };

--- a/src/components/InterstitialTitle.js
+++ b/src/components/InterstitialTitle.js
@@ -6,16 +6,20 @@ const useStyles = createUseStyles(() => ({
   root: {
     textAlign: 'center',
     paddingTop: 24,
-    paddingBottom: 8,
+    paddingBottom: ({ paddingBottom }) => paddingBottom,
+  },
+
+  h2: {
+    margin: 0,
   },
 }));
 
-const InterstitialTitle = ({ text, className }) => {
-  const classes = useStyles();
+const InterstitialTitle = ({ text, className, paddingBottom = 8 }) => {
+  const classes = useStyles({ paddingBottom });
 
   return (
     <div className={classnames(classes.root, className)}>
-      <h2>{text}</h2>
+      <h2 className={classes.h2}>{text}</h2>
     </div>
   );
 };

--- a/src/components/actions/CallToAction.js
+++ b/src/components/actions/CallToAction.js
@@ -134,9 +134,7 @@ const CallToAction = ({
 
         <Button text={buttonText} disabled={disabled} icon={<FaPaperPlane />} />
       </div>
-      <div className={classnames('typography-body', subFormStateClass, classes.subForm)}>
-        {subForm.message}
-      </div>
+      <div className={classnames(subFormStateClass, classes.subForm)}>{subForm.message}</div>
     </form>
   );
 };

--- a/src/components/actions/FormSubmissionModal.js
+++ b/src/components/actions/FormSubmissionModal.js
@@ -50,7 +50,7 @@ const FormSubmissionModal = ({
       <div className={classes.modalContentWrapper}>
         <h2>
           {titleText}{' '}
-          <span aria-label="Party Steamers" role="img">
+          <span aria-label="Party Streamers" role="img">
             🎉
           </span>
         </h2>

--- a/src/components/actions/FormSubmissionModal.js
+++ b/src/components/actions/FormSubmissionModal.js
@@ -32,7 +32,12 @@ const useStyles = createUseStyles((theme) => ({
   },
 }));
 
-const FormSubmissionModal = ({ modalOpen, handleCloseModal }) => {
+const FormSubmissionModal = ({
+  modalOpen,
+  handleCloseModal,
+  titleText = 'Thank you!',
+  bodyText = `We'll be in touch to learn more about your stack and the problems you're trying to solve.`,
+}) => {
   const classes = useStyles();
 
   return (
@@ -44,15 +49,12 @@ const FormSubmissionModal = ({ modalOpen, handleCloseModal }) => {
     >
       <div className={classes.modalContentWrapper}>
         <h2>
-          Thank you!{' '}
+          {titleText}{' '}
           <span aria-label="Party Steamers" role="img">
             🎉
           </span>
         </h2>
-        <p>
-          {`We'll be in touch to learn more about your stack
-            and the problems you're trying to solve.`}
-        </p>
+        <p>{bodyText}</p>
 
         <p>
           In the meantime, you could&nbsp;

--- a/src/components/actions/SubscribeToNewsletter.js
+++ b/src/components/actions/SubscribeToNewsletter.js
@@ -70,9 +70,7 @@ const SubscribeToNewsletter = ({
 
         <Button text={buttonText} disabled={disabled} icon={<FaPaperPlane />} />
       </div>
-      <div className={classnames('typography-body', subFormStateClass, classes.subForm)}>
-        {subForm.message}
-      </div>
+      <div className={classnames(subFormStateClass, classes.subForm)}>{subForm.message}</div>
     </form>
   );
 };

--- a/src/components/actions/SubscribeToNewsletter.js
+++ b/src/components/actions/SubscribeToNewsletter.js
@@ -5,86 +5,22 @@ import { FaPaperPlane } from 'react-icons/fa';
 
 import Button from '../home/Button';
 import { FORM_NAMES } from '../../contactFormConstants';
-
-export const styles = (theme) => ({
-  inputWrapper: {
-    width: '100%',
-    display: 'flex',
-    marginBottom: 8,
-  },
-
-  input: {
-    flex: 1,
-
-    border: 'none',
-    borderLeft: `2px solid ${theme.palette.primary.main}`,
-    borderRadius: 0,
-
-    backgroundColor: theme.palette.grey[100],
-    color: theme.palette.secondary.dark,
-
-    lineHeight: 2,
-    padding: '0.1rem 0.5rem',
-
-    '&:focus': {
-      borderRadius: 0,
-      // Just change the color of the border so the cursor in the input doesn't move.
-      borderLeftColor: 'transparent',
-      outlineWidth: 2,
-      outlineStyle: 'solid',
-      outlineColor: theme.palette.primary.main,
-      // Fixes issue in Firefox where outline is outside the input vs Chrome where it is inside.
-      outlineOffset: -2,
-    },
-
-    '&::placeholder': {
-      color: theme.palette.secondary.light,
-      // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-      opacity: 0.5,
-    },
-  },
-
-  subForm: {
-    fontSize: '1.2rem',
-    color: theme.palette.grey[600],
-    minHeight: 16,
-  },
-
-  subFormerror: {
-    color: theme.palette.deepOrange[700],
-  },
-
-  label: {
-    display: 'none',
-  },
-
-  [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
-    input: {
-      fontSize: '2rem',
-      padding: '0.5rem 0.5rem',
-    },
-  },
-});
+import { styles, encode } from './CallToAction';
 
 const useStyles = createUseStyles(styles);
 
-export const encode = (data) => {
-  const formData = new FormData();
-  Object.keys(data).forEach((k) => {
-    formData.append(k, data[k]);
-  });
-  return formData;
-};
-
-const CallToAction = ({
-  placeholderText = 'Work email',
+const SubscribeToNewsletter = ({
+  placeholderText = 'human@company.com',
   buttonText = 'Click here',
+  subFormMessage = 'We will never sell or share your email address.',
   setModalOpen,
 }) => {
   const classes = useStyles();
   const [email, setEmail] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [subForm, setSubForm] = useState({});
+  const [subForm, setSubForm] = useState({
+    message: subFormMessage,
+  });
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -93,7 +29,7 @@ const CallToAction = ({
     const resp = await fetch('/', {
       method: 'POST',
       body: encode({
-        'form-name': FORM_NAMES.notifyMe,
+        'form-name': FORM_NAMES.subscribeToNewsletter,
         email,
       }),
     });
@@ -141,4 +77,4 @@ const CallToAction = ({
   );
 };
 
-export default CallToAction;
+export default SubscribeToNewsletter;

--- a/src/contactFormConstants.js
+++ b/src/contactFormConstants.js
@@ -1,4 +1,7 @@
 // This is loaded in a NodeJS process.
 // DO NOT put this file in the src/pages directory. Gatsby will complain because it doesn't export
 // a React component.
-exports.FORM_NAME = 'landing-page/notify-me';
+exports.FORM_NAMES = {
+  notifyMe: 'landing-page/notify-me',
+  subscribeToNewsletter: 'subscribe-to-newsletter',
+};

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -45,7 +45,7 @@ const BlogPostTemplate = ({ data, location }) => {
         modalOpen={modalOpen}
         handleCloseModal={handleCloseModal}
         titleText="You're subscribed!"
-        bodyText="Your inbox should receive the first edition within a few days."
+        bodyText="You should receive the first edition within a few days."
       />
 
       <StickyFooter maxWidthBreakpoint={MAX_WIDTH_BREAKPOINT} location={location}>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -6,7 +6,7 @@ import { SEO, InterstitialTitle } from 'components';
 import StickyFooter from 'components/layouts/StickyFooter';
 import PostHeader from 'components/blog/PostHeader';
 import FormSubmissionModal from 'components/actions/FormSubmissionModal';
-import CallToAction from 'components/actions/CallToAction';
+import SubscribeToNewsletter from 'components/actions/SubscribeToNewsletter';
 
 const useStyles = createUseStyles((theme) => ({
   main: theme.preMadeStyles.content,
@@ -14,6 +14,12 @@ const useStyles = createUseStyles((theme) => ({
   callToActionWrapper: {
     paddingTop: 40,
     paddingBottom: 40,
+    textAlign: 'center',
+  },
+
+  callToActionParagraph: {
+    marginBottom: 24,
+    marginTop: 0,
   },
 }));
 
@@ -35,7 +41,12 @@ const BlogPostTemplate = ({ data, location }) => {
         title={post.frontmatter.title}
         description={post.frontmatter.description || post.excerpt}
       />
-      <FormSubmissionModal modalOpen={modalOpen} handleCloseModal={handleCloseModal} />
+      <FormSubmissionModal
+        modalOpen={modalOpen}
+        handleCloseModal={handleCloseModal}
+        titleText="You're subscribed!"
+        bodyText="Your inbox should receive the first edition within a few days."
+      />
 
       <StickyFooter maxWidthBreakpoint={MAX_WIDTH_BREAKPOINT} location={location}>
         <main className={classes.main}>
@@ -46,8 +57,11 @@ const BlogPostTemplate = ({ data, location }) => {
         </main>
 
         <div className={classes.callToActionWrapper}>
-          <InterstitialTitle text="Backstage without the headaches" />
-          <CallToAction setModalOpen={setModalOpen} buttonText="Sign me up!" />
+          <InterstitialTitle text="Become a Backstage expert" />
+          <p className={classes.callToActionParagraph}>
+            Get the latest Backstage news in your inbox each week.
+          </p>
+          <SubscribeToNewsletter setModalOpen={setModalOpen} buttonText="Subscribe" />
         </div>
       </StickyFooter>
     </>


### PR DESCRIPTION
The goal here is to ensure that people who put their emails in the form at the bottom of blog posts end up on a newsletter subscriber list where they will receive the weekly newsletter.

The form submissions are handled by [Netlify's forms feature](https://docs.netlify.com/forms/setup/). Each submission is sent to [Zapier](https://zapier.com), where it is forwarded on to the main subscriber list in [Revue](https://getrevue.co). Doing it this way allows us to keep the Revue API key out of the website out of people's browsers.

When the form is submitted successfully, a modal appears to congratulate them.

Landing page submissions go to a different list than those received from the bottom of blog posts. Those people don't really intend to sign up for a newsletter. We can choose to manually add them to the newsletter if we later get their email consent. I expect we will replace the landing page CTA with a "Get a demo" type flow fairly soon so I thought it wasn't worth messing with this.