### PR TITLE
Add lighthouse annotation to backstage.yaml

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -7,6 +7,7 @@ metadata:
     blog posts, legal policies, landing pages etc.
   annotations:
     github.com/slug: RoadieHQ/marketing-site
+    lighthouse.com/website-url: https://roadie.io/
 spec:
   type: website
   owner: david@roadie.io


### PR DESCRIPTION
Adds a lighthouse annotation to tie a website entity to audits on the deployed site in the lighthouse audit service.