### PR TITLE
Fix: remove highlight from operators in code preview

### DIFF
--- a/src/head-loaded-styles.css
+++ b/src/head-loaded-styles.css
@@ -190,7 +190,6 @@ pre[class*="language-"] {
 	color: #690;
 }
 
-.token.operator,
 .token.entity,
 .token.url,
 .language-css .token.string,


### PR DESCRIPTION
This PR removes highlights from operator in the code preview:

Before:
![o1JSz9M](https://user-images.githubusercontent.com/36006588/97439865-05673180-1927-11eb-846e-a80fc3dd18e0.png)

After:
![2pfwGaX](https://user-images.githubusercontent.com/36006588/97439809-f2546180-1926-11eb-902e-3baff5141ddb.png)
