### PR TITLE
Add Detectify site verification

### DIFF
--- a/static/3a234d4dbfcda5bb15549fbd105314b9.txt
+++ b/static/3a234d4dbfcda5bb15549fbd105314b9.txt
@@ -1,0 +1,1 @@
+detectify


### PR DESCRIPTION
Detectify is a security scanning service which we can add to be more secure. They verify that we own the domain by having us add a file to the root of the website.