### PR TITLE
Remove EM position from careers page

### DIFF
--- a/src/pages/careers.js
+++ b/src/pages/careers.js
@@ -78,14 +78,7 @@ const OPEN_ROLES = [
     },
   ],
 
-  [
-    {
-      title() {
-        return <Link to="/careers/engineering-manager">Engineering Manager</Link>;
-      },
-      text: `Build a top-performing startup engineering team.`,
-    },
-  ],
+  [],
 ];
 
 const Careers = ({ data, location }) => {


### PR DESCRIPTION
We have filled this position so it's best to remove it from the website so we don't waste people's time.

This is a low risk change and everyone is on holidays so I'm going to merge this without review.