### PR TITLE
Say when a blog post tutorial was last validated

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-preset-gatsby": "^0.9.0",
     "classnames": "^2.2.6",
     "gatsby": "^2.30.1",
+    "date-fns": "^2.16.1",
     "gatsby-image": "^2.8.0",
     "gatsby-plugin-google-analytics": "^2.3.6",
     "gatsby-plugin-jss": "^2.3.9",

--- a/src/components/blog/DatePublished.js
+++ b/src/components/blog/DatePublished.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import format from 'date-fns/format';
+import formatDistance from 'date-fns/formatDistance';
+
+const DatePublished = ({
+  frontmatter: { date, lastValidated },
+  relative = false,
+  showLastValidated = false,
+}) => {
+  const FORMAT_TOKEN = 'MMMM do, yyyy';
+  const dateTimestamp = Date.parse(date);
+  const lastValidatedTimestamp = Date.parse(lastValidated);
+
+  let text = '';
+  let formattedDate = formatDistance(dateTimestamp, new Date());
+
+  if (relative) {
+    text = `Published ${formattedDate} ago`;
+  } else {
+    formattedDate = format(dateTimestamp, FORMAT_TOKEN);
+    text = `Published on ${formattedDate}`;
+  }
+
+  if (showLastValidated && lastValidatedTimestamp && lastValidatedTimestamp !== dateTimestamp) {
+    if (relative) {
+      const formattedLastvalidated = formatDistance(lastValidatedTimestamp, new Date());
+      text = `Last validated ${formattedLastvalidated} ago • Originally published ${formattedDate} ago`;
+    } else {
+      const formattedLastvalidated = format(lastValidatedTimestamp, FORMAT_TOKEN);
+      text = `Last validated on ${formattedLastvalidated} • Originally published on ${formattedDate}`;
+    }
+  }
+
+  return <span>{text}</span>;
+};
+
+export default DatePublished;

--- a/src/components/blog/PostHeader.js
+++ b/src/components/blog/PostHeader.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import { createUseStyles } from 'react-jss';
 
+import DatePublished from './DatePublished';
+
 const useStyles = createUseStyles((theme) => ({
   root: {
     marginBottom: '2em',
-  },
-
-  date: {
-    marginTop: 0,
-    marginBottom: 0,
   },
 
   h1: {
@@ -31,7 +28,7 @@ const PostHeader = ({ post }) => {
   return (
     <header className={classes.root}>
       <h1 className={classes.h1}>{post.frontmatter.title}</h1>
-      <p className={classes.date}>{post.frontmatter.date}</p>
+      <DatePublished frontmatter={post.frontmatter} showLastValidated={true} />
     </header>
   );
 };

--- a/src/components/blog/PostSummary.js
+++ b/src/components/blog/PostSummary.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'gatsby';
 import { createUseStyles } from 'react-jss';
 
+import DatePublished from './DatePublished';
+
 const useStyles = createUseStyles((theme) => ({
   root: {
     marginBottom: '4em',
@@ -24,11 +26,6 @@ const useStyles = createUseStyles((theme) => ({
       color: theme.palette.primary.main,
       textDecoration: 'underline',
     },
-  },
-
-  date: {
-    marginTop: 0,
-    marginBottom: 0,
   },
 
   summary: theme.preMadeStyles.content,
@@ -54,7 +51,7 @@ const PostSummary = ({ post }) => {
             {title}
           </Link>
         </h3>
-        <small className={classes.date}>{post.frontmatter.date}</small>
+        <DatePublished frontmatter={post.frontmatter} relative={true} />
       </header>
       <section className={classes.summary}>
         <p dangerouslySetInnerHTML={{ __html: summary }} />

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -39,9 +39,10 @@ export const pageQuery = graphql`
           }
 
           frontmatter {
-            date(formatString: "MMMM DD, YYYY")
+            date
             title
             description
+            lastValidated
           }
         }
       }

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -103,8 +103,9 @@ export const pageQuery = graphql`
       html
       frontmatter {
         title
-        date(formatString: "MMMM DD, YYYY")
+        date
         description
+        lastValidated
       }
     }
   }

--- a/src/templates/Page.js
+++ b/src/templates/Page.js
@@ -52,7 +52,7 @@ export const pageQuery = graphql`
 
       frontmatter {
         title
-        date(formatString: "MMMM DD, YYYY")
+        date
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6174,6 +6174,11 @@ date-fns@^2.14.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"
   integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==
 
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
 date-time@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"


### PR DESCRIPTION
It is useful for the user to know when a tutorial style post was last validated. It helps them guage how likely the code is to be stale.

I'm copying DigitalOcean here. [Look at this post for example](https://www.digitalocean.com/community/tutorials/how-to-build-and-deploy-a-hugo-site-to-digitalocean-app-platform).

![Screenshot 2021-01-10 at 16 43 20](https://user-images.githubusercontent.com/562403/104129084-f824e500-5362-11eb-9494-37b71ee390f7.png)
