### PR TITLE
Fix link to gitops-api plugin

### DIFF
--- a/content/plugins/notes/gitops-clusters.md
+++ b/content/plugins/notes/gitops-clusters.md
@@ -6,7 +6,7 @@ name: gitops-clusters
 
 In order this plugin to work you must install backend plugin available: [here](https://github.com/chanwit/gitops-api).
 
-You might also use ready-to-use Docker image: [https://hub.docker.com/chanwit/gitops-api](https://hub.docker.com/chanwit/gitops-api)
+You might also use ready-to-use Docker image: [https://hub.docker.com/r/chanwit/gitops-api/](https://hub.docker.com/r/chanwit/gitops-api/)
 
 To start using GitOps with Backstage and Docker, rung the following command:
 


### PR DESCRIPTION
I just realized the link is broken: https://hub.docker.com/r/chanwit/gitops-api/