### PR TITLE
Newsletter page

### DIFF
--- a/content/blog/backstage-weekly-14-inernal-features/index.md
+++ b/content/blog/backstage-weekly-14-inernal-features/index.md
@@ -67,4 +67,4 @@ These new docs cover the purpose of the change, the new API, migration steps and
 
 ## Roadie news
 
-We have refreshed our most popular blog post to date. This tutorial walks you through [all the steps needed to get Backstage running with Docker Compose](https://www.notion.so/Newsletter-draft-18th-Jan-2021-8dc81662436440af9cd2e54a9e7e9e4b).
+We have refreshed our most popular blog post to date. This tutorial walks you through [all the steps needed to get Backstage running with Docker Compose](/blog/backstage-docker-service-catalog/).

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,6 @@ module.exports = {
     description: 'Hosted, managed, enterprise Backstage',
     siteUrl: 'https://roadie.io',
     demoUrl: 'https://demo.roadie.so',
-    newsletterUrl: 'https://backstage-weekly.roadie.io',
     social: {
       twitter: 'RoadieHQ',
       github: 'RoadieHQ',

--- a/src/components/SitewideFooter.js
+++ b/src/components/SitewideFooter.js
@@ -39,7 +39,7 @@ const SitewideFooter = () => {
         <div>© {new Date().getFullYear()} Larder Software Limited. All rights reserved.</div>
 
         <nav>
-          <Link to="/backstage-weekly/">Backstage Weekly</Link>
+          <Link to="/careers/">Careers</Link>
           <Link to="/terms/" className={classes.nonFirstLink}>
             Terms of service
           </Link>

--- a/src/components/SitewideFooter.js
+++ b/src/components/SitewideFooter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useStaticQuery, graphql } from 'gatsby';
 import { createUseStyles } from 'react-jss';
 import { CookieConsent, Link } from 'components';
 
@@ -33,16 +32,14 @@ const useStyles = createUseStyles((theme) => ({
 
 const SitewideFooter = () => {
   const classes = useStyles();
-  const data = useStaticQuery(query);
-  const { newsletterUrl } = data.site.siteMetadata;
 
   return (
     <footer>
       <div className={classes.inner}>
-        <div>© {new Date().getFullYear()} Larder, Inc. All rights reserved.</div>
+        <div>© {new Date().getFullYear()} Larder Software Limited. All rights reserved.</div>
 
         <nav>
-          <Link to={newsletterUrl}>Backstage Weekly</Link>
+          <Link to="/backstage-weekly/">Backstage Weekly</Link>
           <Link to="/terms/" className={classes.nonFirstLink}>
             Terms of service
           </Link>
@@ -58,14 +55,3 @@ const SitewideFooter = () => {
 };
 
 export default SitewideFooter;
-
-export const query = graphql`
-  query SitewideFooter {
-    site {
-      siteMetadata {
-        title
-        newsletterUrl
-      }
-    }
-  }
-`;

--- a/src/components/SitewideHeader/HamburgerMenu.js
+++ b/src/components/SitewideHeader/HamburgerMenu.js
@@ -137,7 +137,7 @@ const HamburgerMenu = ({ siteMetadata }) => {
 
         <div className={classes.spacer}>
           <TextLink
-            to={siteMetadata.newsletterUrl}
+            to="/backstage-weekly/"
             text="Backstage Weekly"
             color="contrasting"
             className={classes.textLink}

--- a/src/components/SitewideHeader/index.js
+++ b/src/components/SitewideHeader/index.js
@@ -71,7 +71,6 @@ export const query = graphql`
     site {
       siteMetadata {
         title
-        newsletterUrl
         social {
           twitter
           github

--- a/src/components/SitewideHeader/index.js
+++ b/src/components/SitewideHeader/index.js
@@ -30,7 +30,7 @@ const SitewideHeader = () => {
           </NavItemSpacer>
 
           <NavItemSpacer>
-            <TextLink to="/careers/" text="Careers" />
+            <TextLink to="/backstage-weekly/" text="Backstage Weekly" />
           </NavItemSpacer>
 
           <NavItemSpacer>

--- a/src/components/actions/CallToAction.js
+++ b/src/components/actions/CallToAction.js
@@ -23,7 +23,7 @@ export const styles = (theme) => ({
     backgroundColor: theme.palette.grey[100],
     color: theme.palette.secondary.dark,
 
-    lineHeight: 2,
+    lineHeight: 3,
     padding: '0.1rem 0.5rem',
 
     '&:focus': {
@@ -82,6 +82,7 @@ const CallToAction = ({
   subFormMessage = 'We will never sell or share your email address.',
   netlifyFormName = FORM_NAMES.notifyMe,
   setModalOpen,
+  autoFocus = false,
 }) => {
   const classes = useStyles();
   const [email, setEmail] = useState('');
@@ -101,8 +102,6 @@ const CallToAction = ({
         email,
       }),
     });
-
-    console.log('resp', resp);
 
     if (resp.ok) {
       setModalOpen(true);
@@ -125,6 +124,7 @@ const CallToAction = ({
   const subFormStateClass =
     `subForm${subForm.state}` in classes && classes[`subForm${subForm.state}`];
 
+  /* eslint-disable jsx-a11y/no-autofocus */
   return (
     <form onSubmit={onSubmit}>
       <div className={classes.inputWrapper}>
@@ -137,6 +137,7 @@ const CallToAction = ({
           className={classes.input}
           onChange={onInputChange}
           value={email}
+          autoFocus={autoFocus}
         />
 
         <Button
@@ -149,6 +150,7 @@ const CallToAction = ({
       <div className={classnames(subFormStateClass, classes.subForm)}>{subForm.message}</div>
     </form>
   );
+  /* eslint-enable jsx-a11y/no-autofocus */
 };
 
 export default CallToAction;

--- a/src/components/actions/FormSubmissionModal.js
+++ b/src/components/actions/FormSubmissionModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Modal from 'react-modal';
 import { createUseStyles } from 'react-jss';
+import { Link } from 'components';
 
 const modalStyles = {
   overlay: {
@@ -37,23 +38,13 @@ const twitterUrl = ({ social }) => `https://twitter.com/${social.twitter}`;
 const NewsletterAndTwitterInner = ({ siteMetadata, classes }) => (
   <p>
     Learn more about Backstage via{' '}
-    <a
-      href={siteMetadata.newsletterUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={classes.link}
-    >
+    <Link to="/backstage-weekly/" className={classes.link}>
       our newsletter
-    </a>{' '}
+    </Link>{' '}
     or follow{' '}
-    <a
-      href={twitterUrl(siteMetadata)}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={classes.link}
-    >
+    <Link to={twitterUrl(siteMetadata)} className={classes.link}>
       @{siteMetadata.social.twitter}
-    </a>
+    </Link>
     .
   </p>
 );
@@ -61,14 +52,9 @@ const NewsletterAndTwitterInner = ({ siteMetadata, classes }) => (
 const TwitterInner = ({ siteMetadata, classes }) => (
   <p>
     Follow{' '}
-    <a
-      href={twitterUrl(siteMetadata)}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={classes.link}
-    >
+    <Link to={twitterUrl(siteMetadata)} className={classes.link}>
       @{siteMetadata.social.twitter}
-    </a>
+    </Link>
     .
   </p>
 );

--- a/src/pages/backstage-weekly.js
+++ b/src/pages/backstage-weekly.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { graphql } from 'gatsby';
+import { createUseStyles } from 'react-jss';
+
+import { Lead, SEO, StickyFooter, InterstitialTitle } from 'components';
+import PostSummary from 'components/blog/PostSummary';
+import FormSubmissionModal from 'components/actions/FormSubmissionModal';
+import CallToAction from 'components/actions/CallToAction';
+import { FORM_NAMES } from '../contactFormConstants';
+import roadieRLogo from '../../content/assets/roadie-r-764x764.png';
+
+const useStyles = createUseStyles(() => ({
+  logo: {
+    height: 100,
+  },
+
+  callToActionWrapper: {
+    paddingTop: 40,
+    paddingBottom: 180,
+    textAlign: 'center',
+  },
+
+  callToActionParagraph: {
+    marginBottom: 40,
+    marginTop: 0,
+  },
+}));
+
+const MAX_WIDTH_BREAKPOINT = 'md';
+
+const BlogIndex = ({ data, location }) => {
+  const posts = data.allMarkdownRemark.edges;
+  const siteTitle = data.site.siteMetadata.title;
+  const classes = useStyles();
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <SEO
+        title={`Backstage Weekly Newsletter | ${siteTitle}`}
+        description={`
+          Get the latest Backstage news in your inbox. Keep up to date with the latest
+          releases and changes in this service catalog from Spotify.
+        `}
+      />
+
+      <FormSubmissionModal
+        modalOpen={modalOpen}
+        handleCloseModal={handleCloseModal}
+        titleText="You're subscribed!"
+        bodyText="You should receive the first edition within a week."
+        siteMetadata={data.site.siteMetadata}
+        followOn="TWITTER"
+      />
+
+      <StickyFooter maxWidthBreakpoint={MAX_WIDTH_BREAKPOINT} location={location}>
+        <div className={classes.callToActionWrapper}>
+          <img alt="The Roadie logo" src={roadieRLogo} className={classes.logo} />
+          <InterstitialTitle text="Roadie's Backstage Weekly Newsletter" />
+
+          <p className={classes.callToActionParagraph}>
+            Get the latest news, deep dives into Backstage features, and a roundup of recent
+            open-source action. Track the project without having to watch the GitHub repo.
+          </p>
+
+          {/* I feel this is ok, since subscribing to the newsletter is one of a very
+              small number of actions the user can take on this particular page */}
+          {/* eslint-disable jsx-a11y/no-autofocus */}
+          <CallToAction
+            setModalOpen={setModalOpen}
+            buttonText="Subscribe"
+            netlifyFormName={FORM_NAMES.subscribeToNewsletter}
+            followOn="TWITTER"
+            autoFocus={true}
+          />
+          {/* eslint-enable jsx-a11y/no-autofocus */}
+        </div>
+
+        <Lead>Previous editions</Lead>
+        {posts.map(({ node }) => (
+          <PostSummary key={node.fields.slug} post={node} />
+        ))}
+      </StickyFooter>
+    </>
+  );
+};
+
+export default BlogIndex;
+
+export const pageQuery = graphql`
+  query {
+    allMarkdownRemark(
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: {
+        fileAbsolutePath: { regex: "/.+/blog/.+/" }
+        frontmatter: { tags: { in: ["newsletter"] } }
+      }
+    ) {
+      edges {
+        node {
+          excerpt
+          fields {
+            slug
+          }
+
+          frontmatter {
+            date
+            title
+            description
+            tags
+          }
+        }
+      }
+    }
+
+    site {
+      siteMetadata {
+        title
+        social {
+          twitter
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -12,7 +12,13 @@ const BlogIndex = ({ data, location }) => {
 
   return (
     <>
-      <SEO title={`All blog posts | ${siteTitle}`} />
+      <SEO
+        title={`All blog posts | ${siteTitle}`}
+        description={`
+          The Backstage service catalog from Spotify is an amazing tool for tracking your
+          services and APIs. We write about it here.
+        `}
+      />
 
       <StickyFooter maxWidthBreakpoint={MAX_WIDTH_BREAKPOINT} location={location}>
         {posts.map(({ node }) => (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -158,7 +158,6 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
-        newsletterUrl
         social {
           twitter
         }

--- a/src/pages/onboarding.js
+++ b/src/pages/onboarding.js
@@ -159,7 +159,6 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
-        newsletterUrl
         social {
           twitter
         }

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { graphql } from 'gatsby';
 import { createUseStyles } from 'react-jss';
 
-import { SEO, InterstitialTitle } from 'components';
+import { SEO, InterstitialTitle, Link } from 'components';
 import StickyFooter from 'components/layouts/StickyFooter';
 import PostHeader from 'components/blog/PostHeader';
 import FormSubmissionModal from 'components/actions/FormSubmissionModal';
@@ -29,7 +29,7 @@ const MAX_WIDTH_BREAKPOINT = 'md';
 const BlogPostTemplate = ({ data, location }) => {
   const post = data.markdownRemark;
   const classes = useStyles();
-  const { title: siteTitle, newsletterUrl } = data.site.siteMetadata;
+  const { title: siteTitle } = data.site.siteMetadata;
 
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -66,9 +66,7 @@ const BlogPostTemplate = ({ data, location }) => {
           <p className={classes.callToActionParagraph}>
             To get the latest news, deep dives into Backstage features, and a roundup of recent
             open-source action, sign up for Roadie&apos;s Backstage Weekly.{' '}
-            <a href={newsletterUrl} target="_blank" rel="noopener noreferrer">
-              See recent editions.
-            </a>
+            <Link to="/backstage-weekly/">See recent editions.</Link>
           </p>
 
           <CallToAction
@@ -90,7 +88,6 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
-        newsletterUrl
         social {
           twitter
         }

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -72,7 +72,6 @@ const Header = ({ plugin }) => {
 const PluginTemplate = ({ data, location }) => {
   const classes = useStyles();
   const { plugin, notes, site } = data;
-  const { newsletterUrl } = site.siteMetadata;
 
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -90,7 +89,7 @@ const PluginTemplate = ({ data, location }) => {
       <FormSubmissionModal
         modalOpen={modalOpen}
         handleCloseModal={handleCloseModal}
-        siteMetadata={data.site.siteMetadata}
+        siteMetadata={site.siteMetadata}
         followOn="TWITTER"
       />
 
@@ -133,9 +132,7 @@ const PluginTemplate = ({ data, location }) => {
             <p className={classes.callToActionParagraph}>
               To get the latest news, deep dives into Backstage features, and a roundup of recent
               open-source action, sign up for Roadie&apos;s Backstage Weekly.{' '}
-              <a href={newsletterUrl} target="_blank" rel="noopener noreferrer">
-                See recent editions.
-              </a>
+              <a href="/backstage-weekly/">See recent editions.</a>
             </p>
 
             <CallToAction
@@ -160,7 +157,6 @@ export const pageQuery = graphql`
   query PluginDescriptionByName($name: String!) {
     site {
       siteMetadata {
-        newsletterUrl
         social {
           twitter
         }

--- a/src/templates/Tag.js
+++ b/src/templates/Tag.js
@@ -12,7 +12,12 @@ const BlogIndex = ({ pageContext, data, location }) => {
 
   return (
     <>
-      <SEO title={`All ${tag} blog posts | ${siteTitle}`} />
+      <SEO
+        title={`All ${tag} blog posts | ${siteTitle}`}
+        description={`
+          Blog posts relating to the Backstage service catalog which are tagged with ${tag}.
+        `}
+      />
 
       <StickyFooter maxWidthBreakpoint={MAX_WIDTH_BREAKPOINT} location={location}>
         {posts.map(({ node }) => (
@@ -51,7 +56,6 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
-        newsletterUrl
         social {
           twitter
         }


### PR DESCRIPTION
The newsletter platform we use, Revue, provides [a subscription page](https://backstage-weekly.roadie.io/) where people can subscribe to the newsletter.

![Screenshot 2021-02-01 at 11 20 53](https://user-images.githubusercontent.com/562403/106452292-93e7d380-647f-11eb-9928-be23ccd6e1fa.png)

This commit adds a page with similar function directly to the roadie.io website.

We want people to be able to read the newsletter online easily on our website. However, by having the content duplicated between Revue and roadie.io, we run the risk of paying an SEO penalty. By moving the subscription function fully into roadie.io I can turn off the subscribe page on Revue and remove the duplication.

### After merging

- [ ] 301 redirect https://backstage-weekly.roadie.io to https://roadie.io/backstage-weekly
- [ ] Turn off the subscription page on Revue.