### PR TITLE
Owned by david

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,5 +10,5 @@ metadata:
     lighthouse.com/website-url: https://roadie.io/
 spec:
   type: website
-  owner: group:roadie
+  owner: user:david
   lifecycle: production


### PR DESCRIPTION
Backstage ownership assumes that the owner is a group unless you explicitly specify `user:`.