### PR TITLE
Use slug for legal notices

### DIFF
--- a/content/legal-notices/acceptable-use-policy.md
+++ b/content/legal-notices/acceptable-use-policy.md
@@ -1,5 +1,4 @@
 ---
-name: acceptable-use-policy
 title: Acceptable Use Policy
 lastUpdated: '2021-02-05T21:00:00.0Z'
 description: How you may and may not use our services.

--- a/content/legal-notices/cookies-policy.md
+++ b/content/legal-notices/cookies-policy.md
@@ -1,5 +1,4 @@
 ---
-name: cookies-policy
 title: Cookies Policy
 lastUpdated: '2021-02-05T21:00:00.0Z'
 description: A list of cookies used on the Roadie website.

--- a/content/legal-notices/privacy-policy.md
+++ b/content/legal-notices/privacy-policy.md
@@ -1,5 +1,4 @@
 ---
-name: privacy-policy
 title: Privacy Policy
 lastUpdated: '2020-07-11T21:00:00.0Z'
 description: This Privacy Policy describes Our policies and procedures on the collection, use and disclosure of Your information when You use the Service and tells You about Your privacy rights and how the law protects You.

--- a/content/legal-notices/sub-processors.md
+++ b/content/legal-notices/sub-processors.md
@@ -1,5 +1,4 @@
 ---
-name: sub-processors
 title: Sub-Processors
 lastUpdated: '2021-02-05T21:00:00.0Z'
 description: A list of sub-processors we use.

--- a/content/legal-notices/website-terms.md
+++ b/content/legal-notices/website-terms.md
@@ -1,5 +1,4 @@
 ---
-name: website-terms
 title: Website Terms of Use
 lastUpdated: '2020-07-11T21:00:00.0Z'
 description: Please read these terms and conditions carefully before using Our Service.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -89,10 +89,10 @@ exports.createPages = async ({ graphql, actions }) => {
     actions,
     graphql,
     processor: ({ node }, component) => ({
-      path: `/legal-notices/${node.frontmatter.name}/`,
+      path: `/legal-notices${node.fields.slug}`,
       component,
       context: {
-        name: node.frontmatter.name,
+        slug: node.fields.slug,
       },
     }),
   });

--- a/src/queries/gatsbyNodeQueries.js
+++ b/src/queries/gatsbyNodeQueries.js
@@ -56,10 +56,6 @@ module.exports.LEGAL_NOTICES_QUERY = `
         fields {
           slug
         }
-
-        frontmatter {
-          name
-        }
       }
     }
   }

--- a/src/templates/LegalNotice.js
+++ b/src/templates/LegalNotice.js
@@ -113,7 +113,7 @@ const LegalNotice = ({ data: { notice, site }, location }) => {
 export default LegalNotice;
 
 export const pageQuery = graphql`
-  query LegalNoticeByName($name: String!) {
+  query LegalNoticeBySlug($slug: String!) {
     site {
       siteMetadata {
         title
@@ -123,11 +123,10 @@ export const pageQuery = graphql`
       }
     }
 
-    notice: markdownRemark(frontmatter: { name: { eq: $name } }) {
+    notice: markdownRemark(fields: { slug: { eq: $slug } }) {
       id
       html
       frontmatter {
-        name
         description
         title
         lastUpdated


### PR DESCRIPTION
There is no customer facing impact from this. It just removes a redundant property from the frontmatter of the legal notices.