### PR TITLE
Simplify use of gatsby-source-filesystem

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,18 +20,10 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/content/blog`,
-        name: `blog`,
+        path: `${__dirname}/content`,
+        name: 'content',
         // Ignore stuff like Vim swp files, .DS_Store etc.
-        ignore: ['**/.*'],
-      },
-    },
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        path: `${__dirname}/content/assets`,
-        name: `assets`,
-        ignore: ['**/.*'],
+        ignore: ['**/.*', '**/plugins'],
       },
     },
     {
@@ -48,16 +40,6 @@ module.exports = {
         path: `${__dirname}/content/plugins/notes`,
         name: `pluginNotes`,
         ignore: ['**/template*', '**/.*'],
-      },
-    },
-
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        path: `${__dirname}/content/legal-notices`,
-        name: `legal-notices`,
-        // Ignore stuff like Vim swp files, .DS_Store etc.
-        ignore: ['**/.*'],
       },
     },
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -89,7 +89,7 @@ exports.createPages = async ({ graphql, actions }) => {
     actions,
     graphql,
     processor: ({ node }, component) => ({
-      path: `/legal-notices${node.fields.slug}`,
+      path: node.fields.slug,
       component,
       context: {
         slug: node.fields.slug,
@@ -103,19 +103,10 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 
   if (node.internal.type === `MarkdownRemark`) {
     const value = createFilePath({ node, getNode });
-
-    if (/blog/.test(node.fileAbsolutePath)) {
-      createNodeField({
-        name: `slug`,
-        node,
-        value: `/blog${value}`,
-      });
-    } else {
-      createNodeField({
-        name: `slug`,
-        node,
-        value,
-      });
-    }
+    createNodeField({
+      name: `slug`,
+      node,
+      value,
+    });
   }
 };


### PR DESCRIPTION
I guess I didn't understand how this was supposed to work when I first
started using Gatsby. I had one instance of gatsby-source-filesystem for
each subdirectory of `content`. This would create slugs which didn't
have the correct prefix on them (like `blog/xyz`). I dealt with this by
manually adding the `/blog/` prefix to each URL in `gatsby-node.js`.

A much simpler way is to load all subdirectories of content with one
instance of gatsby-source-filesystem. Then you get the directory names
as part of the URL automatically and the manual prefixing can be removed
from `gatsby-node.js`.

This change is non-user facing. The public URLs of the website should
all remain the same as they are now.