### PR TITLE
Better docs styling on big and small screens

### DIFF
--- a/src/components/doc/Sidebar.js
+++ b/src/components/doc/Sidebar.js
@@ -4,10 +4,9 @@ import { createUseStyles } from 'react-jss';
 import SidebarItem from './SidebarItem';
 
 const useStyles = createUseStyles((theme) => ({
-  root: {
-    borderRight: `1px solid ${theme.palette.grey[300]}`,
-    paddingTop: 32,
-  },
+  root: {},
+
+  inner: {},
 
   section: {
     marginBottom: 32,
@@ -25,6 +24,13 @@ const useStyles = createUseStyles((theme) => ({
   [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
     root: {
       minWidth: 250,
+      borderRight: `1px solid ${theme.palette.grey[300]}`,
+    },
+
+    inner: {
+      paddingTop: 32,
+      position: 'sticky',
+      top: 0,
     },
   },
 }));
@@ -34,45 +40,47 @@ const DocSidebar = ({ location }) => {
 
   return (
     <aside className={classes.root}>
-      <div className={classes.section}>
-        <strong>Documentation</strong>
-      </div>
+      <div className={classes.inner}>
+        <div className={classes.section}>
+          <strong>Documentation</strong>
+        </div>
 
-      <div className={classes.section}>
-        <p>Getting started</p>
+        <div className={classes.section}>
+          <p>Getting started</p>
 
-        <ul className={classes.ul}>
-          <SidebarItem
-            to="/docs/getting-started/getting-started-for-admins/"
-            text="For admins"
-            location={location}
-          />
+          <ul className={classes.ul}>
+            <SidebarItem
+              to="/docs/getting-started/getting-started-for-admins/"
+              text="For admins"
+              location={location}
+            />
 
-          <SidebarItem
-            to="/docs/getting-started/technical-documentation/"
-            text="Using TechDocs"
-            location={location}
-          />
-        </ul>
-      </div>
+            <SidebarItem
+              to="/docs/getting-started/technical-documentation/"
+              text="Using TechDocs"
+              location={location}
+            />
+          </ul>
+        </div>
 
-      <div className={classes.section}>
-        <p>Integrations</p>
+        <div className={classes.section}>
+          <p>Integrations</p>
 
-        <ul className={classes.ul}>
-          <SidebarItem
-            to="/docs/integrations/github-token/"
-            text="GitHub via Token"
-            location={location}
-          />
-          <SidebarItem
-            to="/docs/integrations/github-client/"
-            text="GitHub via Oauth"
-            location={location}
-          />
-          <SidebarItem to="/docs/integrations/sentry/" text="Sentry" location={location} />
-          <SidebarItem to="/docs/integrations/circleci/" text="CircleCI" location={location} />
-        </ul>
+          <ul className={classes.ul}>
+            <SidebarItem
+              to="/docs/integrations/github-token/"
+              text="GitHub via Token"
+              location={location}
+            />
+            <SidebarItem
+              to="/docs/integrations/github-client/"
+              text="GitHub via Oauth"
+              location={location}
+            />
+            <SidebarItem to="/docs/integrations/sentry/" text="Sentry" location={location} />
+            <SidebarItem to="/docs/integrations/circleci/" text="CircleCI" location={location} />
+          </ul>
+        </div>
       </div>
     </aside>
   );

--- a/src/templates/Doc.js
+++ b/src/templates/Doc.js
@@ -8,23 +8,28 @@ import { Sidebar } from 'components/doc';
 const useStyles = createUseStyles((theme) => ({
   content: theme.preMadeStyles.content,
 
-  article: {
-    paddingLeft: 32,
-    paddingTop: 32,
-  },
+  article: {},
 
   main: {},
 
   articleFooter: {
     borderTop: `1px solid ${theme.palette.grey[300]}`,
     marginTop: 48,
-    marginBottom: 48,
     paddingTop: 24,
   },
 
   [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
+    article: {
+      paddingTop: 32,
+      paddingLeft: 32,
+    },
+
     main: {
       display: 'flex',
+    },
+
+    articleFooter: {
+      marginBottom: 48,
     },
   },
 }));

--- a/src/theme.js
+++ b/src/theme.js
@@ -99,6 +99,12 @@ const theme = {
       '& table': {
         borderCollapse: 'collapse',
         marginBottom: '1em',
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        display: 'block',
+        maxWidth: 'fit-content',
+        overflowX: 'auto',
+        whiteSpace: 'nowrap',
       },
 
       '& th, & td': {

--- a/src/theme.js
+++ b/src/theme.js
@@ -67,14 +67,6 @@ const theme = {
         marginTop: 0,
       },
 
-      '& h2': {
-        marginTop: '4em',
-      },
-
-      '& h3': {
-        marginTop: '2em',
-      },
-
       '& ul': {
         paddingLeft: '1em',
       },
@@ -127,6 +119,14 @@ const theme = {
 
         '& ol': {
           paddingLeft: '3em',
+        },
+
+        '& h2': {
+          marginTop: '4em',
+        },
+
+        '& h3': {
+          marginTop: '2em',
         },
 
         '& blockquote': {


### PR DESCRIPTION
Some dedicated changes for bigger screens and mobile.

 1. Don't have such big margins between headings on mobile.
 2. Remove left padding from the main content on mobile.
 3. Remove borders designed to separate content on big screens.
 4. Stick the docs sidebar on big screens.
 5. Horizontal scrolling for tables in markdown documents.

I opened #125 for follow up.