### PR TITLE
Cleanup careers styling

### DIFF
--- a/src/components/TwoColumnPoints.js
+++ b/src/components/TwoColumnPoints.js
@@ -5,11 +5,7 @@ import isFunction from 'lodash/isFunction';
 
 const useStyles = createUseStyles((theme) => ({
   root: {},
-
-  col: {
-    paddingLeft: 16,
-    paddingEight: 16,
-  },
+  col: {},
 
   strong: {
     marginTop: 0,
@@ -24,6 +20,7 @@ const useStyles = createUseStyles((theme) => ({
 
     col: {
       flex: 1,
+      paddingLeft: 16,
     },
   },
 }));

--- a/src/components/careers/Hero.js
+++ b/src/components/careers/Hero.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createUseStyles } from 'react-jss';
-import classnames from 'classnames';
 
 import { LayoutControl, Lead, Headline, ButtonLink } from 'components';
 import { applicationHref } from './links';
@@ -8,13 +7,6 @@ import { applicationHref } from './links';
 const useStyles = createUseStyles(() => ({
   hero: {
     textAlign: 'center',
-    paddingLeft: 16,
-    paddingRight: 16,
-  },
-
-  spacing: {
-    paddingBottom: 24,
-    marginBottom: 40,
   },
 }));
 
@@ -22,7 +14,7 @@ const CareersHero = ({ headline, roleName, typeformSlug }) => {
   const classes = useStyles();
 
   return (
-    <div className={classnames(classes.spacing, classes.hero)}>
+    <div className={classes.hero}>
       <LayoutControl maxWidthBreakpoint="lg">
         <Headline>
           <span>{headline}</span>

--- a/src/components/careers/Main.js
+++ b/src/components/careers/Main.js
@@ -5,17 +5,7 @@ import { LayoutControl, InterstitialTitle, Lead, UnorderedList, OrderedList } fr
 import Mission from './Mission';
 
 const useStyles = createUseStyles((theme) => ({
-  content: {
-    paddingLeft: 16,
-    paddingRight: 16,
-    ...theme.preMadeStyles.content,
-  },
-
-  sitewideHeaderWrapper: {
-    marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
-  },
+  content: theme.preMadeStyles.content,
 
   mainWrapper: {
     display: 'flex',
@@ -29,44 +19,34 @@ const CareersMain = ({ role, requirements, offer, process }) => {
   return (
     <div className={classes.mainWrapper}>
       <main className={classes.content}>
-        <div className={classes.spacing}>
-          <LayoutControl maxWidthBreakpoint="lg">
-            <InterstitialTitle text="Our mission" />
-            <Mission classes={classes} />
-          </LayoutControl>
-        </div>
+        <LayoutControl maxWidthBreakpoint="lg">
+          <InterstitialTitle text="Our mission" />
+          <Mission classes={classes} />
+        </LayoutControl>
 
-        <div className={classes.spacing}>
-          <LayoutControl maxWidthBreakpoint="lg">
-            <InterstitialTitle text="The role" />
-            <UnorderedList content={role} />
-          </LayoutControl>
-        </div>
+        <LayoutControl maxWidthBreakpoint="lg">
+          <InterstitialTitle text="The role" />
+          <UnorderedList content={role} />
+        </LayoutControl>
 
-        <div className={classes.spacing}>
-          <LayoutControl maxWidthBreakpoint="lg">
-            <InterstitialTitle text="The requirements" />
-            <UnorderedList content={requirements} />
-          </LayoutControl>
-        </div>
+        <LayoutControl maxWidthBreakpoint="lg">
+          <InterstitialTitle text="The requirements" />
+          <UnorderedList content={requirements} />
+        </LayoutControl>
 
-        <div className={classes.spacing}>
-          <LayoutControl maxWidthBreakpoint="lg">
-            <InterstitialTitle text="The offer" />
-            <UnorderedList content={offer} />
-          </LayoutControl>
-        </div>
+        <LayoutControl maxWidthBreakpoint="lg">
+          <InterstitialTitle text="The offer" />
+          <UnorderedList content={offer} />
+        </LayoutControl>
 
-        <div className={classes.spacing}>
-          <LayoutControl maxWidthBreakpoint="lg">
-            <InterstitialTitle text="The process" />
-            <Lead>
-              All applicants will receive a response within 3 days. We can&apos;t always be perfect,
-              but we can be quick.
-            </Lead>
-            <OrderedList content={process} />
-          </LayoutControl>
-        </div>
+        <LayoutControl maxWidthBreakpoint="lg">
+          <InterstitialTitle text="The process" />
+          <Lead>
+            All applicants will receive a response within 3 days. We can&apos;t always be perfect,
+            but we can be quick.
+          </Lead>
+          <OrderedList content={process} />
+        </LayoutControl>
       </main>
     </div>
   );

--- a/src/pages/careers.js
+++ b/src/pages/careers.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import { createUseStyles } from 'react-jss';
-import classnames from 'classnames';
 
 import {
   SEO,
@@ -21,19 +20,10 @@ const useStyles = createUseStyles((theme) => ({
     textAlign: 'center',
   },
 
-  spacing: {
-    paddingBottom: 24,
-    marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
-  },
-
   content: theme.preMadeStyles.content,
 
   sitewideHeaderWrapper: {
     marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
   },
 
   mainWrapper: {
@@ -115,7 +105,7 @@ const Careers = ({ data, location }) => {
 
       <div className={classes.mainWrapper}>
         <main className={classes.content}>
-          <div className={classnames(classes.spacing, classes.hero)}>
+          <div className={classes.hero}>
             <LayoutControl maxWidthBreakpoint="lg">
               <Headline>
                 <span>Careers @ {siteTitle}</span>
@@ -125,26 +115,20 @@ const Careers = ({ data, location }) => {
             </LayoutControl>
           </div>
 
-          <div className={classes.spacing}>
-            <LayoutControl maxWidthBreakpoint="lg">
-              <InterstitialTitle text="Our mission" />
-              <Mission classes={classes} />
-            </LayoutControl>
-          </div>
+          <LayoutControl maxWidthBreakpoint="lg">
+            <InterstitialTitle text="Our mission" />
+            <Mission classes={classes} />
+          </LayoutControl>
 
-          <div className={classes.spacing}>
-            <LayoutControl maxWidthBreakpoint="lg">
-              <InterstitialTitle text="Our values" />
-              <TwoColumnPoints content={VALUES} />
-            </LayoutControl>
-          </div>
+          <LayoutControl maxWidthBreakpoint="lg">
+            <InterstitialTitle text="Our values" />
+            <TwoColumnPoints content={VALUES} />
+          </LayoutControl>
 
-          <div className={classes.spacing}>
-            <LayoutControl maxWidthBreakpoint="lg">
-              <InterstitialTitle text="Open roles" />
-              <TwoColumnPoints content={OPEN_ROLES} />
-            </LayoutControl>
-          </div>
+          <LayoutControl maxWidthBreakpoint="lg">
+            <InterstitialTitle text="Open roles" />
+            <TwoColumnPoints content={OPEN_ROLES} />
+          </LayoutControl>
         </main>
       </div>
 

--- a/src/pages/careers/backend-engineer.js
+++ b/src/pages/careers/backend-engineer.js
@@ -13,8 +13,6 @@ import { backstageLink } from 'components/careers/links';
 const useStyles = createUseStyles(() => ({
   sitewideHeaderWrapper: {
     marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
   },
 }));
 

--- a/src/pages/careers/engineering-manager.js
+++ b/src/pages/careers/engineering-manager.js
@@ -11,8 +11,6 @@ import Main from 'components/careers/Main';
 const useStyles = createUseStyles(() => ({
   sitewideHeaderWrapper: {
     marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
   },
 }));
 

--- a/src/pages/careers/javascript-engineer.js
+++ b/src/pages/careers/javascript-engineer.js
@@ -12,8 +12,6 @@ import { backstageLink } from 'components/careers/links';
 const useStyles = createUseStyles(() => ({
   sitewideHeaderWrapper: {
     marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
   },
 }));
 

--- a/src/pages/careers/platform-engineer.js
+++ b/src/pages/careers/platform-engineer.js
@@ -12,8 +12,6 @@ import { backstageLink } from 'components/careers/links';
 const useStyles = createUseStyles(() => ({
   sitewideHeaderWrapper: {
     marginBottom: 40,
-    paddingLeft: 16,
-    paddingRight: 16,
   },
 }));
 


### PR DESCRIPTION
There were some unused styles and HTML tags which are no-longer needed
because

 1. the layout management of the <SitewideHeader /> component changed so
 that it now has it's own <LayoutControl /> component. Thus it doesn't
 need left and right padding.
 2. Headers now make space for themselves based on some spacing controls
 defined in the theme.

 I have cleaned these up and removed some unnecessary tags.