### PR TITLE
Split cookies policies

### DIFF
--- a/content/legal-notices/cookies-policy/v2.md
+++ b/content/legal-notices/cookies-policy/v2.md
@@ -1,0 +1,46 @@
+---
+title: Cookies Policy
+lastUpdated: '2021-03-23T21:00:00.0Z'
+description: A list of cookies used on the Roadie website.
+---
+
+Please read this policy carefully before using our website.
+
+## Information about our use of Cookies
+
+Our website uses cookies to distinguish you from other users of our website. This helps us to provide you with a good experience when you browse our website and also allows us to improve our website. By continuing to use our website, you are agreeing to our use of cookies.
+
+### What are cookies?
+
+A cookie is a small file of letters and numbers that we store on your browser or the hard drive of your computer if you agree. Cookies contain information that is transferred to your computer's hard drive.
+
+## What types of cookies do we use?
+
+There are five main types of cookies:
+
+**Strictly necessary cookies:** these cookies are essential to enable you to login, navigate around and use the features of our website and services, or to provide a service requested by you (such as your username). We do not need to obtain your consent in order to use these cookies. These cookies can be used for security and integrity reasons.
+
+**Functionality cookies:** These cookies allow our services to remember choices you make (such as your language) and provide enhanced and personalized features.
+
+**Performance cookies:** these cookies collect information about your online activity (for example the duration of your visit on our Services), including behavioral data and content engagement metrics. These cookies are used for analytics, research and to perform statistics (based on aggregated information).
+
+**Marketing or advertising cookies:** these cookies are used to deliver tailored offers and advertisements to you, based on your derived interests, as well as to perform email marketing campaigns. They are usually placed by our advertisers (for example advertising networks) and provide them insights about the people who see and interact with their ads, visit their websites or use their app.
+
+You can block cookies by activating the setting on your browser that allows you to refuse the setting of all or some cookies. However, if you use your browser settings to block all cookies (including essential cookies) you may not be able to access all or parts of our website.
+
+Except for essential cookies, all cookies will expire after 1 year.
+
+## Website cookies (roadie.io)
+
+| Cookies        | Type               | Purpose              |
+| -------------- | ------------------ | -------------------- |
+| Google         | Third party cookie | Performance Cookie   |
+| Cookie Consent | First party cookie | Functionality Cookie |
+
+## Platform cookies (roadie.so)
+
+| Cookies        | Type               | Purpose                   |
+| -------------- | ------------------ | ------------------------- |
+| Authentication | First party cookie | Strictly necessary cookie |
+| Google         | Third party cookie | Performance Cookie        |
+| Cookie Consent | First party cookie | Functionality Cookie      |


### PR DESCRIPTION
I have been advised by counsel to split the cookies into two categories: those that exist in the application and those that exist on the website.