### PR TITLE
Adding senior source engineer job description to the site.

### DIFF
--- a/src/components/careers/Main.js
+++ b/src/components/careers/Main.js
@@ -27,7 +27,7 @@ const CareersMain = ({ showOpenSource, role, requirements, offer, process }) => 
           </LayoutControl>
         ) : (
           <LayoutControl maxWidthBreakpoint="lg">
-            <InterstitialTitle text="What is the company's mission 🤔" />
+            <InterstitialTitle text="What is the company's mission? 🤔" />
             <Mission classes={classes} />
           </LayoutControl>
         )}

--- a/src/components/careers/Main.js
+++ b/src/components/careers/Main.js
@@ -3,6 +3,7 @@ import { createUseStyles } from 'react-jss';
 
 import { LayoutControl, InterstitialTitle, Lead, UnorderedList, OrderedList } from 'components';
 import Mission from './Mission';
+import OpenSourceMission from './OpenSourceMission';
 
 const useStyles = createUseStyles((theme) => ({
   content: theme.preMadeStyles.content,
@@ -13,34 +14,47 @@ const useStyles = createUseStyles((theme) => ({
   },
 }));
 
-const CareersMain = ({ role, requirements, offer, process }) => {
+const CareersMain = ({ showOpenSource, role, requirements, offer, process }) => {
   const classes = useStyles();
 
   return (
     <div className={classes.mainWrapper}>
       <main className={classes.content}>
+        {showOpenSource ? (
+          <LayoutControl maxWidthBreakpoint="lg">
+            <InterstitialTitle text="What's the opportunity? 🤔" />
+            <OpenSourceMission classes={classes} />
+          </LayoutControl>
+        ) : (
+          <LayoutControl maxWidthBreakpoint="lg">
+            <InterstitialTitle text="What is the company's mission 🤔" />
+            <Mission classes={classes} />
+          </LayoutControl>
+        )}
         <LayoutControl maxWidthBreakpoint="lg">
-          <InterstitialTitle text="Our mission" />
-          <Mission classes={classes} />
-        </LayoutControl>
-
-        <LayoutControl maxWidthBreakpoint="lg">
-          <InterstitialTitle text="The role" />
+          <InterstitialTitle text="What does my day to day look like? 📅" />
           <UnorderedList content={role} />
         </LayoutControl>
 
         <LayoutControl maxWidthBreakpoint="lg">
-          <InterstitialTitle text="The requirements" />
+          <InterstitialTitle text="What skills do I need? ✨" />
           <UnorderedList content={requirements} />
         </LayoutControl>
 
         <LayoutControl maxWidthBreakpoint="lg">
-          <InterstitialTitle text="The offer" />
+          <InterstitialTitle text="What is the offer? 💙" />
           <UnorderedList content={offer} />
         </LayoutControl>
 
+        {showOpenSource && (
+          <LayoutControl maxWidthBreakpoint="lg">
+            <InterstitialTitle text="What is the company's mission? 🤔" />
+            <Mission classes={classes} />
+          </LayoutControl>
+        )}
+
         <LayoutControl maxWidthBreakpoint="lg">
-          <InterstitialTitle text="The process" />
+          <InterstitialTitle text="What is the process? 📖" />
           <Lead>
             All applicants will receive a response within 3 days. We can&apos;t always be perfect,
             but we can be quick.

--- a/src/components/careers/Main.js
+++ b/src/components/careers/Main.js
@@ -37,7 +37,7 @@ const CareersMain = ({ showOpenSource, role, requirements, offer, process }) => 
         </LayoutControl>
 
         <LayoutControl maxWidthBreakpoint="lg">
-          <InterstitialTitle text="What skills do I need? ✨" />
+          <InterstitialTitle text="What skills would we like to see? ✨" />
           <UnorderedList content={requirements} />
         </LayoutControl>
 

--- a/src/components/careers/OpenSourceMission.js
+++ b/src/components/careers/OpenSourceMission.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const OpenSourceMission = () => (
+  <div>
+    <p>
+      We are looking for an individual with proven leadership skills and a passion for open-source
+      to lead our open-source efforts.
+    </p>
+    <p>
+      Open-source is vital to Roadie.{' '}
+      <a href="https://backstage.io" target="_blank" rel="noopener noreferrer">
+        Backstage
+      </a>{' '}
+      is an open-source service catalog created in Spotify. We rely on Backstage and other notable
+      projects from the open-source community in our day to day operations. We want to share what we
+      build and ensure that we give back to the community. We are hiring staff dedicated to making
+      it better.
+    </p>
+    <p>
+      Roadie is a remote-first team working on building Backstage as a service for engineers. We try
+      to provide a high level of psychological safety, a collaborative environment where we can work
+      on problems together and the ability to work from anywhere.
+    </p>
+  </div>
+);
+
+export default OpenSourceMission;

--- a/src/components/careers/OpenSourceMission.js
+++ b/src/components/careers/OpenSourceMission.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'components';
 
 const OpenSourceMission = () => (
   <div>
@@ -8,9 +9,7 @@ const OpenSourceMission = () => (
     </p>
     <p>
       Open-source is vital to Roadie.{' '}
-      <a href="https://backstage.io" target="_blank" rel="noopener noreferrer">
-        Backstage
-      </a>{' '}
+      <Link to="https://github.com/backstage/backstage">Backstage</Link>
       is an open-source service catalog created in Spotify. We rely on Backstage and other notable
       projects from the open-source community in our day to day operations. We want to share what we
       build and ensure that we give back to the community. We are hiring staff dedicated to making

--- a/src/components/careers/links.js
+++ b/src/components/careers/links.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import { Link } from 'components';
 
 export const applicationHref = (typeformSlug) =>
   `https://roadiehq.typeform.com/to/cdF3Ls?roleslug=${typeformSlug}&utm_source=roadie.io`;
 
 export const backstageLink = renderToString(
-  <a href="https://github.com/backstage/backstage" target="_blank" rel="noopener noreferrer">
-    Backstage
-  </a>
+  <Link to="https://github.com/backstage/backstage">Backstage</Link>
 );

--- a/src/components/careers/links.js
+++ b/src/components/careers/links.js
@@ -6,6 +6,6 @@ export const applicationHref = (typeformSlug) =>
 
 export const backstageLink = renderToString(
   <a href="https://github.com/backstage/backstage" target="_blank" rel="noopener noreferrer">
-    the open-source platform
+    Backstage
   </a>
 );

--- a/src/pages/careers.js
+++ b/src/pages/careers.js
@@ -68,9 +68,9 @@ const OPEN_ROLES = [
   [
     {
       title() {
-        return <Link to="/careers/javascript-engineer/">JavaScript Engineer</Link>;
+        return <Link to="/careers/sr-open-source-engineer/">Senior Open Source Engineer</Link>;
       },
-      text: `Become a top contributor to the open-source software that Roadie is built on.`,
+      text: `Become an integral part of leading our open-source efforts.  `,
     },
   ],
   [

--- a/src/pages/careers/sr-open-source-engineer.js
+++ b/src/pages/careers/sr-open-source-engineer.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import { createUseStyles } from 'react-jss';
+
+import { SEO, SitewideFooter, LayoutControl, SitewideHeader } from 'components';
+import Hero from 'components/careers/Hero';
+import Footer from 'components/careers/Footer';
+import Main from 'components/careers/Main';
+import { backstageLink } from 'components/careers/links';
+
+const useStyles = createUseStyles(() => ({
+  sitewideHeaderWrapper: {
+    marginBottom: 40,
+  },
+}));
+
+const ROLE_NAME = 'Senior Open Source Engineer';
+const TYPEFORM_SLUG = 'sr-open-source-engineer';
+const HEADLINE = 'Become an integral part of leading our open-source efforts.';
+
+const ROLE = (() => {
+  return [
+    `Contributing publicly to open source projects like ${backstageLink}`,
+    `Building  and setting the direction for open source software for Roadie`,
+    `Be part of the ${backstageLink} community by taking part in discussions on discord and GitHub`,
+    `Aim to become a maintainer on the ${backstageLink} repository`,
+  ];
+})();
+
+const REQUIREMENTS = (() => {
+  return [
+    `1-3 years of contributing to open source projects`,
+    `You are comfortable speaking to groups of people representing our projects`,
+    `You are skilled at community management`,
+    `You have written large applications in Typescript or JavaScript`,
+    `You have been writing in React for at least 3 years`,
+    `You are equally comfortable working in the back-end`,
+    `You like to share excellent documentation or blog posts`,
+    `Ability to work and communicate in an online distributed environment`,
+    `Bonus: You maintain your own open-source projects`,
+    `Bonus: You have experience running applications in the cloud`,
+    `Bonus: You have familiarity with Kubernetes.`,
+  ];
+})();
+
+const OFFER = (() => {
+  return [
+    `€90,000 base salary (or equivalent in your currency).`,
+    `0.25% to 0.5% stock options`,
+    `27 days paid time off`,
+    `Work remotely with flexible working hours.`,
+  ];
+})();
+
+const PROCESS = (() => [
+  `Application via Typeform. Click the big button below!`,
+  `Meet with the engineering manager, to see if we're a mutual fit.`,
+  `Technical assessment which is broken up into two parts, a programming part and a system design part.`,
+  `A sample of writing for us to review, from your blog or something new.`,
+  `Meet the founder.`,
+  `Yes/No decision.`,
+])();
+
+const Engineer = ({ data, location }) => {
+  const siteTitle = data.site.siteMetadata.title;
+  const classes = useStyles();
+
+  return (
+    <>
+      <SEO title={`${ROLE_NAME} | Careers at ${siteTitle}`} description={HEADLINE} />
+
+      <div className={classes.sitewideHeaderWrapper}>
+        <LayoutControl maxWidthBreakpoint="lg">
+          <SitewideHeader location={location} />
+        </LayoutControl>
+      </div>
+
+      <Hero headline={HEADLINE} roleName={ROLE_NAME} typeformSlug={TYPEFORM_SLUG} />
+
+      <Main
+        showOpenSource={true}
+        role={ROLE}
+        requirements={REQUIREMENTS}
+        offer={OFFER}
+        process={PROCESS}
+      />
+
+      <Footer typeformSlug={TYPEFORM_SLUG} />
+
+      <LayoutControl maxWidthBreakpoint="lg">
+        <SitewideFooter />
+      </LayoutControl>
+    </>
+  );
+};
+
+export default Engineer;
+
+export const pageQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`;

--- a/src/pages/careers/sr-open-source-engineer.js
+++ b/src/pages/careers/sr-open-source-engineer.js
@@ -14,7 +14,7 @@ const useStyles = createUseStyles(() => ({
   },
 }));
 
-const ROLE_NAME = 'Senior Open Source Engineer';
+const ROLE_NAME = 'Senior open-source engineer';
 const TYPEFORM_SLUG = 'sr-open-source-engineer';
 const HEADLINE = 'Become an integral part of leading our open-source efforts.';
 


### PR DESCRIPTION
I made some changes so I could add a Senior Open Source engineer job description to the website

- I created an open-source mission to be added to open-source jobs going forward

- For open source jobs I moved the company mission down to below the other requirements 

- I added a new sr open-source job. I included some emoji's because [emojis increase engagement](https://www.emojics.com/blog/emojis-increase-user-engagement/)

- I changed the rendering logic to show an open-source mission if the job is an open-source job

- I modified the backstage link to say "Backstage" instead of "the open-source platform" as it does not read well on the job description. I checked it against the other live job

Commands I ran
- [x] Ran through eslint
- [x] Ran tests, there are no tests
- [x] Ran `yarn format` against files that were changed
