### PR TITLE
Update sitewide navigation links

### DIFF
--- a/src/components/SitewideFooter.js
+++ b/src/components/SitewideFooter.js
@@ -44,7 +44,8 @@ const SitewideFooter = () => {
         <nav>
           <Link to="/careers/">Careers</Link>
 
-          <Link to="/legal-notices/website-terms/" className={classes.nonFirstLink}>
+          {/* This link will work in production but not in development. Netlify does the 301. */}
+          <Link to="/legal-notices/terms-of-service/" className={classes.nonFirstLink}>
             Legal
           </Link>
 

--- a/src/components/SitewideHeader/HamburgerMenu.js
+++ b/src/components/SitewideHeader/HamburgerMenu.js
@@ -175,8 +175,9 @@ const HamburgerMenu = ({ siteMetadata }) => {
 
         <div className={classes.legalLinks}>
           <div className={classes.legalSpacer}>
+            {/* This link will work in production but not in development. Netlify does the 301. */}
             <TextLink
-              to="/legal-notices/website-terms/"
+              to="/legal-notices/terms-of-service/"
               text="Legal"
               color="contrasting"
               className={classes.textLink}


### PR DESCRIPTION
I forgot to update the sitewide navigation in the footer when I added the terms of service recently. The links are currently going to the wrong place.