### PR TITLE
Updating compensation details from live job descriptions

### DIFF
--- a/src/pages/careers/javascript-engineer.js
+++ b/src/pages/careers/javascript-engineer.js
@@ -36,10 +36,11 @@ const REQUIREMENTS = (() => {
 
 const OFFER = (() => {
   return [
-    `€50,000 to €70,000 base salary (or equivalent in your currency).`,
-    `0.25% to 0.75% stock options`,
-    `27 days paid time off`,
-    `Work remotely with flexible working hours.`,
+    `This is an excellent opportunity to join a fast-growing venture-backed start-up`,
+    `We offer a competitive salary based on experience`,
+    `We provide a meaningful stock options package`,
+    `27 days paid time off`,   
+    `Working remotely flexible working arrangements.`
   ];
 })();
 

--- a/src/pages/careers/platform-engineer.js
+++ b/src/pages/careers/platform-engineer.js
@@ -39,10 +39,11 @@ const REQUIREMENTS = (() => {
 
 const OFFER = (() => {
   return [
-    `€60,000 to €80,000 base salary (or equivalent in your currency).`,
-    `0.25% to 0.5% stock options`,
-    `27 days paid time off`,
-    `Work remotely with flexible working hours.`,
+    `This is an excellent opportunity to join a fast-growing venture-backed start-up`,
+    `We offer a competitive salary based on experience`,
+    `We provide a meaningful stock options package`,
+    `27 days paid time off`,   
+    `Working remotely flexible working arrangements.`
   ];
 })();
 

--- a/src/pages/careers/sr-open-source-engineer.js
+++ b/src/pages/careers/sr-open-source-engineer.js
@@ -45,10 +45,11 @@ const REQUIREMENTS = (() => {
 
 const OFFER = (() => {
   return [
-    `€90,000 base salary (or equivalent in your currency).`,
-    `0.25% to 0.5% stock options`,
-    `27 days paid time off`,
-    `Work remotely with flexible working hours.`,
+    `This is an excellent opportunity to join a fast-growing venture-backed start-up`,
+    `We offer a competitive salary based on experience`,
+    `We provide a meaningful stock options package`,
+    `27 days paid time off`,   
+    `Working remotely flexible working arrangements.`
   ];
 })();
 


### PR DESCRIPTION
I have received feedback from potential candidates and independents that they are self-selecting out of our hiring process due to comp details on the site. By removing this anchor and getting the person into the funnel, we have a greater chance of converting them as they will fall in love with the product and people as they learn more of the opportunity in front of them.

Change
Replacing salary and equity details with 

- This is an excellent opportunity to join a fast-growing venture-backed start-up

- We offer a competitive salary based on experience

- We provide a meaningful stock options package