### PR TITLE
Remove open mic banner

### DIFF
--- a/src/components/layouts/StickyFooter.js
+++ b/src/components/layouts/StickyFooter.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { createUseStyles } from 'react-jss';
 
 import { LayoutControl, SitewideHeader, SitewideFooter } from 'components';
-import TopBanner from 'components/home/TopBanner';
 
 const useStyles = createUseStyles((theme) => ({
   root: {
@@ -33,8 +32,6 @@ const StickyFooter = ({ children, maxWidthBreakpoint, location, headerBottomBord
   return (
     <div className={classes.root}>
       <div className={classes.expandVertically}>
-        <TopBanner />
-
         <SitewideHeader
           location={location}
           bottomBorder={headerBottomBorder}


### PR DESCRIPTION
The Backstage open mic even is over. I've left the banner in the codebase because there will likely be more events in future.

![Screenshot 2021-04-02 at 14 36 57](https://user-images.githubusercontent.com/562403/113420252-e7fc2f00-93c0-11eb-8867-d087b0976206.png)
