### PR TITLE
Wrap table content

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -105,7 +105,6 @@ const theme = {
         display: 'block',
         maxWidth: 'fit-content',
         overflowX: 'auto',
-        whiteSpace: 'nowrap',
       },
 
       '& th, & td': {


### PR DESCRIPTION
Previously, tables would scroll

![Screenshot 2021-04-16 at 14 47 29](https://user-images.githubusercontent.com/562403/115033761-b441fe80-9ec2-11eb-8c52-86028c4bc288.png)

Now they do this:

![Screenshot 2021-04-16 at 14 48 18](https://user-images.githubusercontent.com/562403/115033849-ccb21900-9ec2-11eb-84de-2781e0048da8.png)


