### PR TITLE
Change tsx highlighting to ts

### DIFF
--- a/content/backstage/plugins/tech-radar.md
+++ b/content/backstage/plugins/tech-radar.md
@@ -45,7 +45,7 @@ To pass own data to plugin use a `getData` prop which expects a `Promise<TechRad
 
 For example:
 
-```tsx
+```ts
 const getData = () =>
   Promise.resolve({
     quadrants: [{ id: 'infrastructure', name: 'Infrastructure' }],


### PR DESCRIPTION
Just a tiny typo on one page. Syntax highlighting wasn't working because `tsx` is not a language identifier that the syntax highlighter understands.