### PR TITLE
Make the 'edit on GitHub' link work

### DIFF
--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -105,6 +105,7 @@ export const pageQuery = graphql`
           twitter
         }
       }
+      sourceCodeUrl
     }
 
     plugin: markdownRemark(fields: { slug: { eq: $slug } }) {

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -101,11 +101,11 @@ export const pageQuery = graphql`
   query PluginBySlug($slug: String!) {
     site {
       siteMetadata {
+        sourceCodeUrl
         social {
           twitter
         }
       }
-      sourceCodeUrl
     }
 
     plugin: markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
Fixes #252 

the problem was that the `sourceCodeUrl` was never queried from the settings and so there was an unintended `undefined` in the URL to edit the plugin installation instructions.