### PR TITLE
Fix sentry integration docs

### DIFF
--- a/content/docs/getting-started/getting-started-for-admins/index.md
+++ b/content/docs/getting-started/getting-started-for-admins/index.md
@@ -50,7 +50,7 @@ Want to use a token with more restrictive scopes? Use [this guide](/docs/integra
 
 Visit the Developer Settings of your GitHub organization account. Click "New OAuth App".
 
-Fill out the following information in the form. Be sure to replace `your-company` with your Roadie subdomain.
+Fill out the following information in the form. ⚠️ &nbsp;Be sure to replace `your-company` with your Roadie subdomain.
 
 | Form Field                 | Value                                                                    |
 | -------------------------- | ------------------------------------------------------------------------ |

--- a/content/docs/integrations/sentry/index.md
+++ b/content/docs/integrations/sentry/index.md
@@ -42,7 +42,7 @@ Copy the token that Sentry displays.
 
 Visit `https://your-company.roadie.so/secrets`.
 
-Click the pencil icon beside `SENTRY_TOKEN`. Enter the token you copied from the Sentry UI into the input in the dialog that pops up.
+Click the pencil icon beside `SENTRY_TOKEN`. Prefix the token you copied from the Sentry UI with `Bearer `, and enter it into the input in the dialog that pops up.
 
 ![a dialog box with an input called Secret Value. The Sentry token is pasted inside.](./dialog-on-roadie-secrets.png)
 


### PR DESCRIPTION
`Bearer` is needed before the Sentry API token but the docs don't mention this.