### PR TITLE
Improved form styling on mobile sizes

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -24,7 +24,7 @@ const useStyles = createUseStyles((theme) => ({
     textDecoration: 'none',
 
     borderRadius: 0,
-    padding: '0.1rem 0.8rem',
+    padding: '1rem 0.8rem',
     fontSize: '2rem',
 
     '&:hover': ({ color }) => {
@@ -55,7 +55,7 @@ const useStyles = createUseStyles((theme) => ({
   [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
     root: {
       lineHeight: 1.5,
-      padding: '0.5rem 1rem',
+      padding: '0.1rem 1rem',
     },
   },
 }));

--- a/src/components/SitewideHeader/styles.js
+++ b/src/components/SitewideHeader/styles.js
@@ -9,7 +9,7 @@ export default (theme) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingTop: '1em',
+    paddingTop: '0.4em',
   },
 
   fullScreenNav: {

--- a/src/components/actions/EmailCaptureForm.js
+++ b/src/components/actions/EmailCaptureForm.js
@@ -10,6 +10,7 @@ const styles = (theme) => ({
     width: '100%',
     display: 'flex',
     marginBottom: 8,
+    flexDirection: 'column',
   },
 
   input: {
@@ -22,8 +23,10 @@ const styles = (theme) => ({
     backgroundColor: theme.palette.grey[100],
     color: theme.palette.secondary.dark,
 
-    lineHeight: 3,
-    padding: '0.1rem 0.5rem',
+    lineHeight: 2,
+    fontSize: '2rem',
+    padding: '0.5rem',
+    marginBottom: 8,
 
     '&:focus': {
       borderRadius: 0,
@@ -57,6 +60,11 @@ const styles = (theme) => ({
     input: {
       fontSize: '2rem',
       padding: '0.5rem 0.5rem',
+      marginBottom: 0,
+    },
+
+    inputWrapper: {
+      flexDirection: 'row',
     },
   },
 });

--- a/src/components/home/Hero/index.js
+++ b/src/components/home/Hero/index.js
@@ -7,7 +7,7 @@ import { GetInstanceFormCallToAction } from 'components/CallToAction';
 import IntroToRoadieModal from './IntroToRoadieModal';
 import Adornment from './Adornment';
 
-const useStyles = createUseStyles(() => ({
+const useStyles = createUseStyles((theme) => ({
   headlineWrapper: {
     marginBottom: 32,
   },
@@ -22,11 +22,16 @@ const useStyles = createUseStyles(() => ({
 
   leftCol: {
     paddingTop: 0,
-    paddingRight: 32,
   },
 
   rightCol: {
     paddingLeft: 32,
+  },
+
+  [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
+    leftCol: {
+      paddingRight: 32,
+    },
   },
 }));
 


### PR DESCRIPTION
Previously, email forms would look quite cramped on small screen sizes. Other than 2 spots on the homepage, this form is used on `/backstage-weekly/` and at the bottom of blog posts.

Before:

![roadie io_](https://user-images.githubusercontent.com/562403/125153141-a5798980-e149-11eb-8845-c97ed7feb534.png)

After:

![localhost_8000_](https://user-images.githubusercontent.com/562403/125153148-aca09780-e149-11eb-95c1-e3ce37d0003e.png)
