### PR TITLE
Add info on permissions required for install

### DIFF
--- a/content/docs/getting-started/getting-started-for-admins/index.md
+++ b/content/docs/getting-started/getting-started-for-admins/index.md
@@ -71,6 +71,22 @@ By default, GitHub adds your account to the team as a member. You are now an adm
 
 ℹ️  &nbsp;It can take some time for Roadie to refresh the list of teams from GitHub teams. If you do not see admin functions immediately, please wait a few minutes and try again.
 
+### More Information on Permissions Needed
+The GitHub permissions that Roadie needs are all read only.
+
+You can also choose to allow access to all repos, or select the repos that you would like to give permission to: 
+![image](https://user-images.githubusercontent.com/42720161/127188857-bf3af155-142c-4a4e-b918-369b93823efb.png)
+
+
+**Here is a description of each of the permissions requested:**
+- **Actions (read)** - enables the Backstage plugin that renders Github workflow actions on the component page.
+- **Code (read)** - backstage makes use of a yaml config file, generally kept in the root directory of a GitHub project. Backstage needs read access to the code so  that it can read the backstage catalog config file.
+- **Members (read)** - This allows Backstage to authenticate users of your Github org and ensure only users of your organisation can access it. It also allows for ownership to be assigned and displayed for each service. 
+- **Metadata (read)** - This gives Roadie read only access to various pieces of metadata about the  GitHub organisation used only in order to enable functionality.
+- **Organisation administration (read)** - Enables the API to show Roadie the interaction limits for a user. 
+- **Security events (read)** - This allows Backstage to render a security insights plugin on the component page.
+
+
 ## Next steps
 
 Let's [add a component to Backstage](/docs/getting-started/adding-components/).


### PR DESCRIPTION
Adding information on the permissions required of Github by Roadie when installing and configuring Roadie.