### PR TITLE
Fix undeclared variable

### DIFF
--- a/content/backstage/plugins/argo-cd.md
+++ b/content/backstage/plugins/argo-cd.md
@@ -45,7 +45,7 @@ gettingStarted:
     code: | 
       // packages/app/src/components/catalog/EntityPage.tsx
       import {
-        EntityArgoCDHistoryCard,
+        EntityArgoCDOverviewCard,
         isArgocdAvailable
       } from '@roadiehq/backstage-plugin-argo-cd';
     


### PR DESCRIPTION
Import is calling `EntityArgoCDHistoryCard` while the associated Grid item being called is `EntityArgoCDOverviewCard`. This causes builds to fail due to missing asset. This brings parity to the naming and makes plugin easily usable. 