### PR TITLE
Remove honeypot forms

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,25 +1,10 @@
 const React = require('react');
 const fs = require('fs');
-const map = require('lodash/map');
-
-const { FORM_NAMES } = require('./src/contactFormConstants');
 
 const HEAD_CSS = fs.readFileSync('src/stylesheets/head-loaded-styles.css').toString();
 
-// <form netlify... /> is here to trigger the netlify bot into making form submissions available
-// for this website. If I put the tags on the form which actually performs the submission
-// then it doesn't work. I believe that form is rendered too dynamically to trigger the netlify
-// bot. This form doesn't do any actual work on the site for users.
-const embeddedForms = map(FORM_NAMES, (value) => (
-  <form name={value} netlify="true" netlify-honeypot="bot-field" hidden key="form">
-    <input type="email" name="email" />
-  </form>
-));
-
-exports.onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
+exports.onRenderBody = ({ setHeadComponents }) => {
   // Getting these into the head so the fonts start loading fast and we don't have a FoUC.
   // Have to use dangerouslySetInnerHTML to prevent escaping of quotation marks in the CSS.
   setHeadComponents([<style key="inline-styles" dangerouslySetInnerHTML={{ __html: HEAD_CSS }} />]);
-
-  setPostBodyComponents(embeddedForms);
 };

--- a/src/components/CallToAction/index.js
+++ b/src/components/CallToAction/index.js
@@ -62,6 +62,7 @@ export const GetInstanceFormCallToAction = ({ ...props }) => {
       onSubmit={visitGetBackstageForm}
       subForm={subForm}
       submitting={submitting}
+      netlifyFormName={FORM_NAMES.getInstance}
       {...props}
     />
   );

--- a/src/components/actions/EmailCaptureForm.js
+++ b/src/components/actions/EmailCaptureForm.js
@@ -82,6 +82,7 @@ const EmailCaptureForm = ({
   subForm,
   setEmail,
   submitting = false,
+  netlifyFormName,
 }) => {
   const classes = useStyles();
 
@@ -96,6 +97,8 @@ const EmailCaptureForm = ({
   /* eslint-disable jsx-a11y/no-autofocus */
   return (
     <form onSubmit={onSubmit}>
+      <input type="hidden" name="form-name" value={netlifyFormName} />
+
       <div className={classes.inputWrapper}>
         <input
           type="email"

--- a/src/components/actions/NetlifyFormCallToAction.js
+++ b/src/components/actions/NetlifyFormCallToAction.js
@@ -37,7 +37,7 @@ const NetlifyFormCallToAction = ({
   placeholderText = 'Work email',
   buttonText = 'Click here',
   subFormMessage = 'We will never sell or share your email address.',
-  netlifyFormName = FORM_NAMES.notifyMe,
+  netlifyFormName = FORM_NAMES.getInstance,
   setModalOpen,
   autoFocus = false,
   email,
@@ -80,6 +80,7 @@ const NetlifyFormCallToAction = ({
       email={email}
       buttonText={buttonText}
       autoFocus={autoFocus}
+      netlifyFormName={netlifyFormName}
     />
   );
   /* eslint-enable jsx-a11y/no-autofocus */

--- a/src/contactFormConstants.js
+++ b/src/contactFormConstants.js
@@ -5,9 +5,6 @@
 // These unique names allow us to figure out what a user was looking for when they submit
 // their email address. They show up in Netlify as emails sorted into different lists.
 exports.FORM_NAMES = {
-  notifyMe: 'landing-page/notify-me',
   subscribeToNewsletter: 'subscribe-to-newsletter',
-  getDemo: 'get-demo',
-  getDemoOnboarding: 'get-demo-onboarding',
   getInstance: 'submit-get-instance-form',
 };


### PR DESCRIPTION
According to [this](https://www.netlify.com/blog/2017/07/20/how-to-integrate-netlifys-form-handling-in-a-react-app/#form-handling-with-static-site-generators), I should be able to remove the static forms.