### PR TITLE
Continue to use old form name

### DIFF
--- a/src/components/CallToAction/index.js
+++ b/src/components/CallToAction/index.js
@@ -25,7 +25,7 @@ export const GetInstanceFormCallToAction = ({ ...props }) => {
   const [submitting, setSubmitting] = useState(false);
   const [email, setEmail] = useState('');
   const ctaButtonLabel = 'Get Backstage';
-  const netlifyFormName = FORM_NAMES.getInstanceSplitTesting;
+  const netlifyFormName = FORM_NAMES.getInstance;
   const [subForm, setSubForm] = useState({
     message: 'We will never sell or share your email address',
   });

--- a/src/contactFormConstants.js
+++ b/src/contactFormConstants.js
@@ -7,5 +7,4 @@
 exports.FORM_NAMES = {
   subscribeToNewsletter: 'subscribe-to-newsletter',
   getInstance: 'submit-get-instance-form',
-  getInstanceSplitTesting: 'get-instance-split-testing',
 };


### PR DESCRIPTION
I accidentally left in the form name which I was testing with.

[ch3890]