### PR TITLE
Mention GitHub apps where needed

### DIFF
--- a/content/backstage/plugins/github-actions.md
+++ b/content/backstage/plugins/github-actions.md
@@ -19,7 +19,7 @@ coverImageAlt: 'A list of builds for the Spotify Backstage repo with status and 
 
 gettingStarted: # What will this step accomplish?
   - intro: |
-      Follow our [instructions to create a GitHub OAuth app for Backstage](/blog/github-auth-backstage/).
+      If your Backstage instance is using a Personal Access Token to authenticate against GitHub, you will need to follow our [instructions to create a GitHub OAuth app for Backstage](/blog/github-auth-backstage/). No extra authentication mechanism is required if you are already using a GitHub app with Backstage.
 
   - intro: Install the plugin into your Backstage instance.
     language: bash

--- a/content/backstage/plugins/github-actions.md
+++ b/content/backstage/plugins/github-actions.md
@@ -19,7 +19,12 @@ coverImageAlt: 'A list of builds for the Spotify Backstage repo with status and 
 
 gettingStarted: # What will this step accomplish?
   - intro: |
-      If your Backstage instance is using a Personal Access Token to authenticate against GitHub, you will need to follow our [instructions to create a GitHub OAuth app for Backstage](/blog/github-auth-backstage/). No extra authentication mechanism is required if you are already using a GitHub app with Backstage.
+      If you are using Roadie, or you are using a GitHub app with self-hosted Backstage, OAuth
+      is already configured for use with the GitHub APIs. You can simply install the plugin and it
+      should work automatically.
+
+      If your Backstage instance is using a Personal Access Token to authenticate against GitHub,
+      you will need to follow our [instructions to create a GitHub OAuth app for Backstage](/blog/github-auth-backstage/).
 
   - intro: Install the plugin into your Backstage instance.
     language: bash

--- a/content/blog/github-auth-backstage/index.md
+++ b/content/blog/github-auth-backstage/index.md
@@ -1,13 +1,20 @@
 ---
 title: Using GitHub Auth with Backstage
 date: '2020-08-05T21:00:00.0Z'
-description: Setting up GitHub autententication can be a little tricky, but this post will tell you everything you need to know.
+description: Setting up GitHub authentication can be a little tricky, but this post will tell you everything you need to know.
+lastUpdated: '2021-09-14T21:00:00.0Z'
 tags: ['tutorial', 'github']
 ---
 
+**Update Sept 2021:** Backstage now supports GitHub authentication via GitHub apps. If you are using a GitHub app, you do not need to follow the steps described below. They are only valid if you are using a GitHub Personal Access Token with Backstage.
+
+<br />
+<hr />
+<br />
+
 GitHub is one of the most popular Backstage authentication mechanisms going. There's a good reason for this, Backstage ultimately needs to pull service catalog information from YAML files, those YAML files usually live in git, and the git repos usually live on GitHub.
 
-Setting up GitHub autententication can be a little tricky, but this post will tell you everything you need to know.
+Setting up GitHub authentication can be a little tricky, but this post will tell you everything you need to know.
 
 There are basically two steps:
 


### PR DESCRIPTION
Stop pushing users towards creating an OAuth app when they are already using GitHub apps.

Relates to https://github.com/backstage/backstage/issues/6976