### PR TITLE
Link pages to free-trial page

### DIFF
--- a/src/components/home/FooterCTA.js
+++ b/src/components/home/FooterCTA.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GetInstanceFormCallToAction } from 'components/CallToAction';
+import { ButtonLinkCallToAction } from 'components/CallToAction';
 import { createUseStyles } from 'react-jss';
 
 const useStyles = createUseStyles(() => ({
@@ -19,7 +19,7 @@ const FooterCTA = () => {
   return (
     <div className={classes.callToActionWrapper}>
       <div className={classes.callToActionWrapperInner}>
-        <GetInstanceFormCallToAction />
+        <ButtonLinkCallToAction text="Try it free" fullWidth />
       </div>
     </div>
   );

--- a/src/pages/backstage/docker-image.js
+++ b/src/pages/backstage/docker-image.js
@@ -56,7 +56,7 @@ const BackstageDocker = ({ data, location }) => {
           <p>To learn how to customize Backstage, check out the <Link to="https://backstage.io/docs/getting-started/">official getting started guide</Link>.</p>
 
           <h2>Want to get started even faster?</h2>
-          <p>Check out <Link to="/">Roadie&apos;s no-code SaaS Backstage platform</Link>.</p>
+          <p>Check out <Link to="/free-trial/">Roadie&apos;s no-code SaaS Backstage platform</Link>.</p>
         </article>
 
       </StickyFooter>

--- a/src/pages/developer-portal.js
+++ b/src/pages/developer-portal.js
@@ -8,7 +8,7 @@ import {
   PageMargins,
 } from 'components';
 // eslint-disable-next-line import/named
-import { Testimonial, Hero, FooterCTA, features } from 'components/home';
+import { Hero, FooterCTA, features, IntegrationsList } from 'components/home';
 
 const SEO_TITLE = 'Backstage Developer Portal';
 const HEADLINE = 'Ship faster with a powerful developer portal';
@@ -30,10 +30,6 @@ const Home = ({ data, location }) => {
           </ResponsiveSpacer>
 
           <ResponsiveSpacer>
-            <Testimonial />
-          </ResponsiveSpacer>
-
-          <ResponsiveSpacer>
             <InterstitialTitle
               id="product"
               size="large"
@@ -45,6 +41,20 @@ const Home = ({ data, location }) => {
           {features.quickEasySetup}
           {features.customPlugins}
           {features.securityMaintenance}
+
+          <ResponsiveSpacer>
+            <InterstitialTitle
+              id="integrations"
+              size="large"
+            >
+              Pre-loaded with all your favorite plugins
+            </InterstitialTitle>
+          </ResponsiveSpacer>
+
+          <ResponsiveSpacer>
+            <IntegrationsList />
+          </ResponsiveSpacer>
+
 
           <ResponsiveSpacer>
             <InterstitialTitle

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -64,7 +64,7 @@ const PluginTemplate = ({ data, location }) => {
             <div className={classes.notes}>
               <p>
                 Don&apos;t want to spend your time installing and upgrading Backstage plugins?{' '}
-                <Link to="/" color="primary">Get managed Backstage</Link> from Roadie.
+                <Link to="/free-trial/" color="primary">Get managed Backstage</Link> from Roadie.
               </p>
             </div>
 


### PR DESCRIPTION
Now that we have a dedicated free-trial page, we can link to it from some places in the site.

1. Change FooterCTA
2. /deverloper-portal/ page
3. Docker image page