### PR TITLE
Ch2820 - Update Sentry auth token instructions

### DIFF
--- a/content/docs/integrations/sentry/index.md
+++ b/content/docs/integrations/sentry/index.md
@@ -44,7 +44,7 @@ Copy the token that Sentry displays.
 
 Visit `https://your-company.roadie.so/administration/settings/secrets`.
 
-Click the pencil icon beside `SENTRY_TOKEN`. Prefix the token you copied from the Sentry UI with `Bearer `, and enter it into the input in the dialog that pops up.
+Click the pencil icon beside `SENTRY_TOKEN`. Enter the token you copied from the Sentry UI into the input in the dialog that pops up.
 
 ![a dialog box with an input called Secret Value. The Sentry token is pasted inside.](./dialog-on-roadie-secrets.png)
 


### PR DESCRIPTION
As part of https://app.shortcut.com/larder/story/2820/prefix-bearer-on-sentry-token we are now automatically prefixing the `Bearer` part to the Sentry token on the backend so no longer need customers to enter their token with the prefix - https://github.com/RoadieHQ/roadie/pull/122 

