### PR TITLE
Revert accidental breaking change

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -96,6 +96,21 @@ exports.createPages = async ({ graphql, actions }) => {
   });
 
   await createPagesFromQuery({
+    templatePath: './src/templates/Doc.js',
+    query: DOCS_QUERY,
+    resultName: 'docs.edges',
+    actions,
+    graphql,
+    processor: ({ node }, component) => ({
+      path: node.fields.slug,
+      component,
+      context: {
+        slug: node.fields.slug,
+      },
+    }),
+  });
+
+  await createPagesFromQuery({
     templatePath: './src/templates/CaseStudy.js',
     query: CASE_STUDIES_QUERY,
     resultName: 'caseStudies.edges',


### PR DESCRIPTION
https://app.shortcut.com/larder/story/4285/migrate-the-docs

I accidentally sent a breaking change to `main`. We don't want to create pages from the tailwind Doc.js template INSTEAD of the old Doc.js template, we want to create them IN ADDITION to the old Doc.js template.

Luckily I hadn't actually made any changes to the tailwind Doc.js template when I copied it over, so there was no impact of this breaking change.