### PR TITLE
Remove duplicate NotFoundPage export

### DIFF
--- a/src/pages/tailwind/404.js
+++ b/src/pages/tailwind/404.js
@@ -50,7 +50,7 @@ const links = [
   },
 ];
 
-export const NotFoundPage = ({ data }) => {
+const NotFoundPage = ({ data }) => {
   const siteTitle = data.site.siteMetadata.title;
 
   return (


### PR DESCRIPTION
Was causing this warning in the logs:

```
success write out requires - 0.001s
warn
/Users/davidtuite/dev/roadiehq/marketing-site/src/pages/tailwind/404.js
  53:1  warning  In page templates only a default export of a valid React component and the named export of a page query is allowed.
        All other named exports will cause Fast Refresh to not preserve local component state and do a full refresh.

        Please move your other named exports to another file. Also make sure that you only export page queries that use the "graphql" tag from "gatsby".
  limited-exports-page-templates
```