### PR TITLE
allow installation steps to be left out

### DIFF
--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -63,8 +63,9 @@ const PluginTemplate = ({ data }) => {
             </div>
           </ResponsiveSpacer>
 
+          {plugin.frontmatter.gettingStarted && (
           <ResponsiveSpacer>
-            <div className="text-center pb-3">
+            <div className="text-center pb-3" >
               <Title text="Installation steps" />
             </div>
 
@@ -83,6 +84,7 @@ const PluginTemplate = ({ data }) => {
               )
             )}
           </ResponsiveSpacer>
+          )}
 
           <ResponsiveSpacer>
             <div className="prose prose-primary">


### PR DESCRIPTION
The installation steps were assuming that the steps would include code snippets
but in the case of templates you need text and screenshots.