### PR TITLE
Adding the frame-src CSP setting

### DIFF
--- a/content/backstage/plugins/datadog.md
+++ b/content/backstage/plugins/datadog.md
@@ -164,6 +164,19 @@ metadata:
     datadoghq.com/graph-token: <<TOKEN>
 ```
 
+
+## Set frame-src in Content Security Policy
+
+```
+// app-config.yaml
+backend:
+  csp:
+    frame-src: 
+      # Allow your Datadog URL for @roadiehq/backstage-plugin-datadog
+      - 'DATADOG_SOURCE'
+      - 'DATADOG_DASBOARD_SOURCE'
+```
+
 ## Security
 
 Sharing Datadog dashboards and graphs makes them public on the internet and accessible by anyone with the URL. 


### PR DESCRIPTION
The installation of datadog plugin also requires us to set the frame-src  in app-config.yaml to prevent Backstage from using the default-src settings. 