### PR TITLE
Disable source maps in production

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -140,3 +140,11 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     });
   }
 };
+
+exports.onCreateWebpackConfig = ({ getConfig, actions }) => {
+  if (getConfig().mode === 'production') {
+    actions.setWebpackConfig({
+      devtool: false,
+    });
+  }
+};


### PR DESCRIPTION
https://blog.marcnuri.com/gatsby-disable-source-maps-production