### PR TITLE
turn off webp in gatsby-remark-images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -101,7 +101,6 @@ module.exports = {
               // Gatsby remark images plugin will add inline styles into the element which override
               // anything we try to set.
               wrapperStyle: 'margin-left:unset; margin-right:unset',
-              withWebp: true,
             },
           },
           {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -101,6 +101,10 @@ module.exports = {
               // Gatsby remark images plugin will add inline styles into the element which override
               // anything we try to set.
               wrapperStyle: 'margin-left:unset; margin-right:unset',
+              // Enabling this will add 6+ minutes to the production build time because
+              // gatsby-remark-images needs to process twice as many images. It's a good thing
+              // for end users but watch for the build times!
+              withWebp: false,
             },
           },
           {


### PR DESCRIPTION
https://app.shortcut.com/larder/story/5642/speed-up-marketing-site-builds

This is the [description of what this option does](https://www.gatsbyjs.com/plugins/gatsby-remark-images/).

> Additionally generate WebP versions alongside your chosen file format. They are added as a srcset with the appropriate mimetype and will be loaded in browsers that support the format.

It's a good thing for users, and will reduce image bandwidth 25% for users in the most common browsers, but we are hitting the build time limit on Netlify and deployments are failing and this seems to be the easiest way to reclaim a large amount of time.

We can look at re-introducing this once we figure out how to make image processing more efficient.