### PR TITLE
Consistent title alignment in blog posts

### DIFF
--- a/src/components/article/PostSummary.js
+++ b/src/components/article/PostSummary.js
@@ -30,7 +30,8 @@ const PostSummary = ({ post, className }) => (
     </div>
 
     <div className="flex-1 bg-white p-6 flex flex-col justify-between">
-      <div>
+      {/* min-height ensures the content below the tags is aligned even when there are no tags */}
+      <div className="min-h-[24px]">
         <Tags tags={post.frontmatter.tags} />
       </div>
 


### PR DESCRIPTION
Before this change, titles without tags are misaligned...

![Screenshot 2022-01-26 at 08 54 09](https://user-images.githubusercontent.com/562403/151132552-6b09ee3d-938c-4df8-a1ac-ad5cb0077910.png)