### PR TITLE
Add required annotations doc

### DIFF
--- a/content/docs/docs-nav.yaml
+++ b/content/docs/docs-nav.yaml
@@ -36,6 +36,7 @@ nav:
     - Sonarqube: '/docs/integrations/sonarqube/'
     - Travis ci: '/docs/integrations/travis-ci/'
     - Tech radar: '/docs/configuration/tech-radar/'
+    - Required annotations: '/docs/integrations/required-annotations'
   - Custom plugins:
     - Artifactory: '/docs/custom-plugins/artifactory/'
     - Configuring: '/docs/custom-plugins/configuring/'

--- a/content/docs/integrations/required-annotations/index.md
+++ b/content/docs/integrations/required-annotations/index.md
@@ -29,5 +29,5 @@ In order to use some of the plugins, you may need to add annotations in catalog-
 | @backstage/plugin-jenkins | Jenkins |jenkins.io/github-folder |
 | @backstage/plugin-pagerduty | Pagerduty |pagerduty.com/integration-key |
 | @backstage/plugin-rollbar |Rollbar |rollbar.com/project-slug |
-| backstage-plugin-snyk | Snyk |'snyk.io/org-name' and 'snyk.io/project-ids' |
+| backstage-plugin-snyk | Snyk |snyk.io/org-name and snyk.io/project-ids |
 | @k-phoen/backstage-plugin-opsgenie |Opsgenie|opsgenie.com/component-selector |

--- a/content/docs/integrations/required-annotations/index.md
+++ b/content/docs/integrations/required-annotations/index.md
@@ -1,0 +1,32 @@
+---
+title: Required annotations
+publishedDate: '2022-02-124T09:00:00.0Z'
+description: List of needed annotations for each plugin.
+---
+
+## Introduction
+
+In order to use some of the plugins, you may need to add annotations in catalog-info.yaml files. Below, in the table, you will find a list of the plugins and required annotations you may need to add. You can read more about annotations and what they represent in [Backstage documentations](https://backstage.io/docs/features/software-catalog/well-known-annotations).
+
+
+| Plugin  | Required Annotations          |
+| ------- | ------------------ |
+| @roadiehq/backstage-plugin-github-pull-requests  | github.com/project-slug |
+| @roadiehq/backstage-plugin-github-insights| github.com/project-slug |
+| @roadiehq/backstage-plugin-argo-cd| argocd/app-name or argocd/project-name |
+| @roadiehq/backstage-plugin-aws-lambda| aws.com/lambda-function-name |
+| @roadiehq/backstage-plugin-bugsnag| bugsnag.com/project-key |
+| @roadiehq/backstage-plugin-buildkite | buildkite.com/project-slug |
+| @roadiehq/backstage-plugin-datadog | datadoghq.com/site' or 'datadoghq.com/dashboard-url |
+| @roadiehq/backstage-plugin-firebase-functions| cloud.google.com/function-ids |
+| @roadiehq/backstage-plugin-jira | jira/project-key |
+| @roadiehq/backstage-plugin-security-insights | github.com/project-slug |
+| @roadiehq/backstage-plugin-travis-ci | travis-ci.com/repo-slug |
+| @roadiehq/backstage-plugin-security-insights | github.com/project-slug |
+| @roadiehq/backstage-plugin-prometheus | prometheus.io/rule or prometheus.io/alert |
+| @backstage/plugin-sonarqube | sonarqube.org/project-key |
+| @backstage/plugin-circleci | circleci.com/project-slug |
+| @backstage/plugin-cloudbuild | google.com/cloudbuild-project-slug |
+| @backstage/plugin-jenkins | jenkins.io/github-folder |
+| @k-phoen/backstage-plugin-opsgenie | opsgenie.com/component-selector |
+| @backstage/plugin-rollbar | rollbar.com/project-slug |

--- a/content/docs/integrations/required-annotations/index.md
+++ b/content/docs/integrations/required-annotations/index.md
@@ -27,5 +27,7 @@ In order to use some of the plugins, you may need to add annotations in catalog-
 | @backstage/plugin-circleci |Circle CI  |circleci.com/project-slug |
 | @backstage/plugin-cloudbuild |CLoudbuild |google.com/cloudbuild-project-slug |
 | @backstage/plugin-jenkins | Jenkins |jenkins.io/github-folder |
-| @k-phoen/backstage-plugin-opsgenie |Opsgenie|opsgenie.com/component-selector |
+| @backstage/plugin-pagerduty | Pagerduty |pagerduty.com/integration-key |
 | @backstage/plugin-rollbar |Rollbar |rollbar.com/project-slug |
+| backstage-plugin-snyk | Snyk |'snyk.io/org-name' and 'snyk.io/project-ids' |
+| @k-phoen/backstage-plugin-opsgenie |Opsgenie|opsgenie.com/component-selector |

--- a/content/docs/integrations/required-annotations/index.md
+++ b/content/docs/integrations/required-annotations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Required annotations
-publishedDate: '2022-02-124T09:00:00.0Z'
+publishedDate: '2022-02-24T09:00:00.0Z'
 description: List of needed annotations for each plugin.
 ---
 

--- a/content/docs/integrations/required-annotations/index.md
+++ b/content/docs/integrations/required-annotations/index.md
@@ -9,24 +9,23 @@ description: List of needed annotations for each plugin.
 In order to use some of the plugins, you may need to add annotations in catalog-info.yaml files. Below, in the table, you will find a list of the plugins and required annotations you may need to add. You can read more about annotations and what they represent in [Backstage documentations](https://backstage.io/docs/features/software-catalog/well-known-annotations).
 
 
-| Plugin  | Required Annotations          |
-| ------- | ------------------ |
-| @roadiehq/backstage-plugin-github-pull-requests  | github.com/project-slug |
-| @roadiehq/backstage-plugin-github-insights| github.com/project-slug |
-| @roadiehq/backstage-plugin-argo-cd| argocd/app-name or argocd/project-name |
-| @roadiehq/backstage-plugin-aws-lambda| aws.com/lambda-function-name |
-| @roadiehq/backstage-plugin-bugsnag| bugsnag.com/project-key |
-| @roadiehq/backstage-plugin-buildkite | buildkite.com/project-slug |
-| @roadiehq/backstage-plugin-datadog | datadoghq.com/site' or 'datadoghq.com/dashboard-url |
-| @roadiehq/backstage-plugin-firebase-functions| cloud.google.com/function-ids |
-| @roadiehq/backstage-plugin-jira | jira/project-key |
-| @roadiehq/backstage-plugin-security-insights | github.com/project-slug |
-| @roadiehq/backstage-plugin-travis-ci | travis-ci.com/repo-slug |
-| @roadiehq/backstage-plugin-security-insights | github.com/project-slug |
-| @roadiehq/backstage-plugin-prometheus | prometheus.io/rule or prometheus.io/alert |
-| @backstage/plugin-sonarqube | sonarqube.org/project-key |
-| @backstage/plugin-circleci | circleci.com/project-slug |
-| @backstage/plugin-cloudbuild | google.com/cloudbuild-project-slug |
-| @backstage/plugin-jenkins | jenkins.io/github-folder |
-| @k-phoen/backstage-plugin-opsgenie | opsgenie.com/component-selector |
-| @backstage/plugin-rollbar | rollbar.com/project-slug |
+| Package  | Plugin name | Required Annotations          |
+| ------- | ------------------ |------------------ |
+| @roadiehq/backstage-plugin-github-pull-requests | Github Pull Requests | github.com/project-slug |
+| @roadiehq/backstage-plugin-github-insights| Github Insights | github.com/project-slug |
+| @roadiehq/backstage-plugin-argo-cd| Argo CD |argocd/app-name or argocd/project-name |
+| @roadiehq/backstage-plugin-aws-lambda|AWS Lambda |aws.com/lambda-function-name |
+| @roadiehq/backstage-plugin-bugsnag| Bugsnag |bugsnag.com/project-key |
+| @roadiehq/backstage-plugin-buildkite | Bulidkite|buildkite.com/project-slug |
+| @roadiehq/backstage-plugin-datadog | Datadog |datadoghq.com/site or datadoghq.com/dashboard-url |
+| @roadiehq/backstage-plugin-firebase-functions|Firebase Functions |cloud.google.com/function-ids |
+| @roadiehq/backstage-plugin-jira | Jira |jira/project-key |
+| @roadiehq/backstage-plugin-security-insights |Security Insights |github.com/project-slug |
+| @roadiehq/backstage-plugin-travis-ci |Travis CI |travis-ci.com/repo-slug |
+| @roadiehq/backstage-plugin-prometheus | Prometheus |prometheus.io/rule or prometheus.io/alert |
+| @backstage/plugin-sonarqube | Sonarqube |sonarqube.org/project-key |
+| @backstage/plugin-circleci |Circle CI  |circleci.com/project-slug |
+| @backstage/plugin-cloudbuild |CLoudbuild |google.com/cloudbuild-project-slug |
+| @backstage/plugin-jenkins | Jenkins |jenkins.io/github-folder |
+| @k-phoen/backstage-plugin-opsgenie |Opsgenie|opsgenie.com/component-selector |
+| @backstage/plugin-rollbar |Rollbar |rollbar.com/project-slug |


### PR DESCRIPTION
This page will have an easy preview of all required plugins annotations. It will be used for sad views/missing annotation

Preview URL: https://deploy-preview-595--roadie.netlify.app/docs/integrations/required-annotations/