### PR TITLE
Remove techdocs-core plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,3 @@ nav:
   - Changelog: changelog.md
   - Customer logos: customer-logos.md
   - Legal notices: legal-notices.md
-
-plugins:
-  - techdocs-core


### PR DESCRIPTION
This should be possible now that https://github.com/backstage/backstage/pull/9556 is merged.