### PR TITLE
Fix weird formatting on the iframe docs

### DIFF
--- a/content/docs/integrations/iframe/index.md
+++ b/content/docs/integrations/iframe/index.md
@@ -71,17 +71,17 @@ Then enter the following props.
 
 ![](props.png)
 
-    ```json
-    {
-      "src": "<your src>",
-      "title": "<card title>"
-    }
-    ```
+``` json
+{
+  "src": "<your src>",
+  "title": "<card title>"
+}
+```
 
-    - `src` is url location of the iframe (without this, it will render text)
-    - `title` the title you want to associate the iframe with (optional)
-    - `height` the height of the iframe tag (optional)
-    - `width` the wifth of the iframe tag(optional)
+- `src` is url location of the iframe (without this, it will render text)
+- `title` the title you want to associate the iframe with (optional)
+- `height` the height of the iframe tag (optional)
+- `width` the wifth of the iframe tag(optional)
 
 2.  Click Save
 


### PR DESCRIPTION
<img width="793" alt="Screenshot 2022-04-25 at 16 17 14" src="https://user-images.githubusercontent.com/24317810/165119742-d3ce3ba7-f1e4-4762-9a2e-d5b827324f1b.png">
