### PR TITLE
Remove netlify-plugin-gatsby-cache

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -88,9 +88,3 @@
   from = "/docs/configurations/tech-radar/"
   to = "/docs/integrations/tech-radar/"
   force = true
-
-[build]
-  publish = "public"
-
-[[plugins]]
-  package = "netlify-plugin-gatsby-cache"


### PR DESCRIPTION
It's deprecated and being double installed on Netlify anyway.

https://github.com/jlengstorf/netlify-plugin-gatsby-cache