### PR TITLE
Fix typos in documentation

### DIFF
--- a/content/docs/details/scaffolder/index.md
+++ b/content/docs/details/scaffolder/index.md
@@ -520,7 +520,7 @@ steps:
       sourcePatch: "./repoRoot"
 ```
 
-Collaborators can be added to the repository using the `collaborators` option. It takes an array of `username` and `access`. `username` is the GitHub username to allow collaboration. The `access` option gives the user specfic type of permissions. The options are `pull`, `push`, `admin`, `maintain` or `triage`.
+Collaborators can be added to the repository using the `collaborators` option. It takes an array of `username` and `access`. `username` is the GitHub username to allow collaboration. The `access` option gives the user specific type of permissions. The options are `pull`, `push`, `admin`, `maintain` or `triage`.
 
 ```yaml
 steps:
@@ -531,7 +531,7 @@ steps:
       repoUrl: "github.com?repo=newreponame&owner=AcmeInc"
       collaborators:
         - username: user1
-          access: read
+          access: admin
 ```
 
 The `topics` allows adding topics to the created repository when its created.


### PR DESCRIPTION
https://app.shortcut.com/larder/story/9200/relativity-scaffolder-github-actions-dispatch-error

This contains small typo fix and correct access added as an example