### PR TITLE
Add kubecon page placeholder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -94,3 +94,9 @@
   from = "/security/responsible-disclosure/"
   to = "/"
   force = true
+
+# We'll create a dedicated landing page for people coming from KubeCon 
+[[redirects]]
+  from = "/kubernetes/"
+  to = "/"
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -98,5 +98,5 @@
 # We'll create a dedicated landing page for people coming from KubeCon 
 [[redirects]]
   from = "/kubernetes/"
-  to = "/"
+  to = "/backstage/plugins/kubernetes/"
   force = true


### PR DESCRIPTION
## Motivation

We'll have links from KubeCon pointing to a dedicated page that will be centered on what Roadie can do for Kubernetes users. 

## Approach

We need to commit to a link by July 29th, so I'm adding a route that just redirects to the index while we have the actual page ready. 