### PR TITLE
Typo fix on menu

### DIFF
--- a/content/docs/docs-nav.yaml
+++ b/content/docs/docs-nav.yaml
@@ -57,7 +57,7 @@ nav:
     - Configuring: '/docs/custom-plugins/configuring/'
     - Proxy: '/docs/custom-plugins/proxy/'
   - In-depth:
-    - GtHub app permissions: '/docs/details/github-app-permissions/'
+    - GitHub app permissions: '/docs/details/github-app-permissions/'
     - Configure GitHub Enterprise: '/docs/details/github-enterprise/'
     - Setting secrets: '/docs/details/setting-secrets/'
     - Updating the UI: '/docs/details/updating-the-ui/'


### PR DESCRIPTION
Just a quick fix to a typo I found whilst reading the docs

![image](https://user-images.githubusercontent.com/7665910/181742006-0fa5cbe0-7a0c-4cd7-8079-c8451b0d1647.png)
