### PR TITLE
Add link to catalog faq page

### DIFF
--- a/content/docs/getting-started/adding-components/index.md
+++ b/content/docs/getting-started/adding-components/index.md
@@ -65,6 +65,11 @@ You can check this by going to the Github settings of a repo that Backstage alre
 
 ![repo permissions](./repopermissions.png)
 
+
+**Something Else?**
+
+You can find more [common catalog issues and their fixes here](/docs/details/troubleshooting-the-catalog/). 
+
 ## What Next? 
 
 Let's [add some docs to the component we just created](/docs/getting-started/technical-documentation/) so that others in your organization can easily learn how to use it.


### PR DESCRIPTION
Adds a link on the `Adding Components` page FAQ to the full Catalog FAQ page. 