### PR TITLE
Pin techdoc/cli temporarily due to bug

### DIFF
--- a/content/docs/getting-started/technical-documentation/index.md
+++ b/content/docs/getting-started/technical-documentation/index.md
@@ -99,13 +99,15 @@ You can generate / serve your docs locally to view what they would look like whe
 To generate the docs to the site directory of the project you can run the following command:
 
 ```bash
-npx @techdocs/cli generate --docker-image roadiehq/techdocs
+npx @techdocs/cli@1.2.0 generate --docker-image roadiehq/techdocs
 ```
 
 To start a local server at port 3000 containing the generated docs, you can run the following command:
 ```bash
-npx @techdocs/cli serve --docker-image roadiehq/techdocs
+npx @techdocs/cli@1.2.0 serve --docker-image roadiehq/techdocs
 ```
+
+NB: We need to pin to an earlier version until [this bug](https://github.com/backstage/backstage/issues/13813) in @techdocs/cli@1.2.1 is fixed in the Open Source project.
 
 ### Step 5: Publish your documentation
 


### PR DESCRIPTION
https://app.shortcut.com/larder/story/11151/einride-local-techdocs-generation-fails-with-no-implementation-available-for-apiref-plugin-search-queryservice

This is the bug upstream https://github.com/backstage/backstage/issues/13813