### PR TITLE
Adds redirect placeholder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -100,3 +100,9 @@
   from = "/kubernetes/"
   to = "/backstage/plugins/kubernetes/"
   force = true
+
+# To be later filled in with a typeform URL 
+[[redirects]]
+  from = "/techinsights-demo-backstagecon/"
+  to = "/request-demo/"
+  force = true


### PR DESCRIPTION
### Motivation

We want to have a dedicated form for people coming from the post-conference email but we have not created that form yet. However, we must submit the copy to the CNCF today.

### Approach

I'm creating a redirect rule that takes you to the default request demo page. Once we have the form URL, I'll change the redirect to point there. 