### PR TITLE
Remove reference to manual / CI triggering of custom pipeline

### DIFF
--- a/content/docs/custom-plugins/configuring/index.md
+++ b/content/docs/custom-plugins/configuring/index.md
@@ -47,10 +47,7 @@ List of components that the plugin exposes. These are defined as a type and name
 
 ### Step 2. Installing
 
-Custom plugins are installed when the application is rebuilt.  This rebuilding phase and plugin installation happens on an external workflow. This workflow can be triggered in a number of ways:
-1. By calling a webhook from your CI pipeline,
-2. By calling a webhook manually
-3. Automatically when a new NPM package is published to private, secure Roadie Artifactory.
+Custom plugins are installed when the application is rebuilt.  This rebuilding phase and plugin installation happens on an external workflow. This workflow is triggered automatically when a new NPM package is published to private, secure Roadie Artifactory.
 
 Application update process happens automatically after the workflow is triggered and has run successfully.
 


### PR DESCRIPTION
I propose we remove references to users being able to programatically trigger the custom plugins pipeline. We don't have any users doing this but our documentation has these options as 1, 2 which seems to encourage this (and personally I don't think we should).  

While we certainly can do this I think for now we should keep it internal as a workaround if a user needs it. It's not ideal as the we have to 1) supply / handover the token manually 2) the webhook url is an AWS LB url which has changed in the past 3) document the request they need to send. All of these seem like internal details to me.