### PR TITLE
Create a flow to the custom plugins docs

### DIFF
--- a/content/docs/custom-plugins/configuring/index.md
+++ b/content/docs/custom-plugins/configuring/index.md
@@ -47,7 +47,7 @@ List of components that the plugin exposes. These are defined as a type and name
 
 ### Step 2. Installing
 
-Custom plugins are installed when the application is rebuilt.  This rebuilding phase and plugin installation happens on an external workflow. This workflow is triggered automatically when a new NPM package is published to private, secure Roadie Artifactory.
+Custom plugins are installed when the application is rebuilt. This rebuilding phase and plugin installation happens on an external workflow. This workflow is triggered automatically when a new NPM package is published to private, secure Roadie Artifactory. To publish your plugin follow [these instructions](/docs/custom-plugins/artifactory/)
 
 Application update process happens automatically after the workflow is triggered and has run successfully.
 
@@ -90,8 +90,9 @@ be used as part of the UI.
 
 Build notifications are sent onto a Slack channel where you can see the time that the build took, as well as possible versions of the plugins that have been installed to your Roadie instance.
 
-## Conclusion
+## Next Steps
 
-After a successful installation you will be able to add components from your custom plugin into the Roadie instance. Components can be added as Cards, Tabs or Pages into component pages or to the sidebar.
+* If you haven't already [publish your plugin](/docs/custom-plugins/artifactory/) to our artifactory.
+* After a successful installation you will be able to [add components](/docs/details/updating-the-ui) from your custom plugin into the Roadie instance. Components can be added as Cards, Tabs or Pages into component pages or to the sidebar.
 
 [backstage-plugin-documentation]: https://backstage.io/docs/plugins/create-a-plugin

--- a/content/docs/docs-nav.yaml
+++ b/content/docs/docs-nav.yaml
@@ -55,8 +55,8 @@ nav:
     - Google Cloud Platform: '/docs/integrations/gcp/'
     - Google OAuth client: '/docs/integrations/google-oauth-client/'
   - Custom plugins:
-    - Artifactory: '/docs/custom-plugins/artifactory/'
-    - Configuring: '/docs/custom-plugins/configuring/'
+    - Configuration: '/docs/custom-plugins/configuring/'
+    - Publishing Plugins: '/docs/custom-plugins/artifactory/'
     - Proxy: '/docs/custom-plugins/proxy/'
   - In-depth:
     - GitHub app permissions: '/docs/details/github-app-permissions/'


### PR DESCRIPTION
Add links to the other custom plugins docs so this can be used as the "entry point" to custom plugins. The path of least resistance is where the user configures the plugin before they trigger a build, that way the first version is built into the application (while this might not be the intuitive order given how the feature works now I think this is best?).