### PR TITLE
Link to github discovery docs & reproduce BitBucket processor url docs 

### DIFF
--- a/content/docs/docs-nav.yaml
+++ b/content/docs/docs-nav.yaml
@@ -50,6 +50,7 @@ nav:
   - Integrations:
     - AWS S3: '/docs/integrations/aws-s3/'
     - Bitbucket: '/docs/integrations/bitbucket/'
+    - GitHub Discovery: '/docs/integrations/github-discovery/'
     - GitHub org: '/docs/integrations/github-teams/'
     - GitHub token: '/docs/integrations/github-token/'
     - Google Cloud Platform: '/docs/integrations/gcp/'


### PR DESCRIPTION
Create a link to the github discovery docs in integrations.

Also reproduce the BitBucket url format docs as we're still using the processor but the upstream has removed these docs from the website.