### PR TITLE
Adds cover image to blog post and meta headers

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -5,7 +5,7 @@ import get from 'lodash/get';
 
 import roadieLogo from '../../content/assets/logos/roadie/roadie-racks-og-image.png';
 
-const SEO = ({ title, description = '', lang = 'en', meta = [] }) => {
+const SEO = ({ title, description = '', lang = 'en', headerImage = '', meta = [] }) => {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -25,7 +25,7 @@ const SEO = ({ title, description = '', lang = 'en', meta = [] }) => {
 
   const metaDescription = description || site.siteMetadata.description;
   const twitterHandle = get(site, 'siteMetadata.social.twitter', 'roadiehq');
-  const ogImageUrl = `${site.siteMetadata.siteUrl}${roadieLogo}`;
+  const ogImageUrl = headerImage || `${site.siteMetadata.siteUrl}${roadieLogo}`;
   const ogImageAlt = 'The Roadie logo. A cube in isometric projection with 3 fins cut into the right face. The word Roadie is below.';
 
   const defaultMeta = [{

--- a/src/pages/backstage-weekly.js
+++ b/src/pages/backstage-weekly.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { graphql } from 'gatsby';
 
 import { SEO, Page, Headline, Lead } from 'components';
-import { TitleAndDescription, PubDate, HeadRssLink } from 'components/article';
+import { TitleAndDescription, PubDate } from 'components/article';
 import {
   NetlifyFormCallToAction,
   SubscribeToNewsletterSuccessModal,

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -1,13 +1,9 @@
 import React, { useState } from 'react';
 import { graphql } from 'gatsby';
 
-import {
-  SEO,
-  ContentHeader,
-  SitewideHeader,
-  SitewideFooter,
-} from 'components';
+import { SEO, ContentHeader, SitewideHeader, SitewideFooter } from 'components';
 import HeadRssLink from 'components/article/HeadRssLink';
+import { GatsbyImage, getImage, getSrc } from "gatsby-plugin-image"
 import {
   SubscribeToNewsletterSuccessModal,
   SubscribeToNewsletterCTA,
@@ -29,11 +25,14 @@ const BlogPostTemplate = ({ data }) => {
     setEmail('');
   };
 
+  const coverImage = getImage(post.coverImage);
+
   return (
     <>
       <SEO
         title={`${post.frontmatter.title} | ${siteTitle}`}
         description={post.frontmatter.description || post.excerpt}
+        headerImage={getSrc(post.coverImage)}
       />
 
       <HeadRssLink />
@@ -53,6 +52,8 @@ const BlogPostTemplate = ({ data }) => {
             <ContentHeader frontmatter={post.frontmatter} />
           </div>
 
+          { coverImage && <GatsbyImage image={coverImage} alt={post.coverImage.title} className="mb-6" /> }
+
           <section
             className="prose prose-primary max-w-none"
             dangerouslySetInnerHTML={{ __html: post.html }}
@@ -60,11 +61,7 @@ const BlogPostTemplate = ({ data }) => {
         </article>
 
         <div className="relative max-w-lg mx-auto lg:max-w-xl">
-          <SubscribeToNewsletterCTA
-            setModalOpen={setModalOpen}
-            email={email}
-            setEmail={setEmail}
-          />
+          <SubscribeToNewsletterCTA setModalOpen={setModalOpen} email={email} setEmail={setEmail} />
         </div>
       </main>
 
@@ -86,7 +83,7 @@ export const pageQuery = graphql`
       }
     }
 
-    markdownRemark: contentfulBlogPost(slug: {eq: $slug}) {
+    markdownRemark: contentfulBlogPost(slug: { eq: $slug }) {
       title
       date
       author {
@@ -100,6 +97,10 @@ export const pageQuery = graphql`
         childMarkdownRemark {
           html
         }
+      }
+      coverImage {
+        gatsbyImageData(height: 500)
+        title
       }
     }
   }

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby';
 
 import { SEO, ContentHeader, SitewideHeader, SitewideFooter } from 'components';
 import HeadRssLink from 'components/article/HeadRssLink';
-import { GatsbyImage, getImage, getSrc } from "gatsby-plugin-image"
+import { GatsbyImage, getImage, getSrc } from 'gatsby-plugin-image';
 import {
   SubscribeToNewsletterSuccessModal,
   SubscribeToNewsletterCTA,
@@ -52,7 +52,9 @@ const BlogPostTemplate = ({ data }) => {
             <ContentHeader frontmatter={post.frontmatter} />
           </div>
 
-          { coverImage && <GatsbyImage image={coverImage} alt={post.coverImage.title} className="mb-6" /> }
+          {coverImage && (
+            <GatsbyImage image={coverImage} alt={post.coverImage.title} className="mb-6" />
+          )}
 
           <section
             className="prose prose-primary max-w-none"


### PR DESCRIPTION
## Motivation

When sharing blog posts, I'd like there to be an image related to the article on the preview link. 

## Approach

I'm showing the cover image on the blog post body and adding it to the meta tags. 

## Screenshots

Post on LinkedIn before:
![Screenshot 2022-11-23 at 15 34 09](https://user-images.githubusercontent.com/4451393/203573386-4748785f-e83f-4808-ab94-c25c8ff2e9b1.png)

After this PR:
![Screenshot 2022-11-23 at 15 34 30](https://user-images.githubusercontent.com/4451393/203573460-741eecb6-57ab-4fda-9af7-4008c4a28990.png)
