### PR TITLE
Add green "available on roadie" tags

### DIFF
--- a/content/backstage/plugins/apache-airflow.md
+++ b/content/backstage/plugins/apache-airflow.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/apache-airflow/apache-airflow-logo.png'
 coverImage: '../../assets/apache-airflow-plugin.pmg'
 coverImageAlt: 'A list of DAGs in a table along with instance versioning and status.'
 
+availableOnRoadie: true
+roadieDocsPath: /apache-airflow/
+
 gettingStarted:
   # What will this step accomplish?
   - intro: Install the plugin

--- a/content/backstage/plugins/api-docs.md
+++ b/content/backstage/plugins/api-docs.md
@@ -17,16 +17,15 @@ logoImage: '../../assets/logos/api-docs/logo-docs.png'
 coverImage: '../../assets/api-docs-plugin.png'
 coverImageAlt: 'A screenshot of the API Docs. It is showing a available endpoints for a sample component.'
 
+availableOnRoadie: true
+
 # Instructions for someone who wants to use this plugin.
 # languages used here must be listed in the .babelrc
 gettingStarted:
-  # What will this step accomplish?
-  - language: bash
-    code: |
-      The plugin is already added when using `npx @backstage/create-app` 
-      so you can skip these steps. However, if you are not using create-app
+  - intro: |
+      This plugin is already added when using `npx @backstage/create-app` 
+      so you can usually skip these steps. However, if you are not using create-app
       you can follow the steps below.
-  - intro: Install the plugin into Backstage.
     language: bash
     code: 'yarn add @backstage/plugin-api-docs'
   - intro: 'Add the ApiExplorerPage extension to the app:'

--- a/content/backstage/plugins/argo-cd.md
+++ b/content/backstage/plugins/argo-cd.md
@@ -18,6 +18,9 @@ logoImage: '../../assets/logos/argo-cd/argo-cd-logo.png'
 coverImage: '../../assets/argo-cd-plugin.png'
 coverImageAlt: 'A preview of Argo CD overview widget including kubernetes pod status.'
 
+availableOnRoadie: true
+roadieDocsPath: /argocd/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/bugsnag.md
+++ b/content/backstage/plugins/bugsnag.md
@@ -16,6 +16,9 @@ coverImage: '../../assets/backstage/plugins/bugsnag/backstage-bugsnag-plugin.png
 coverImageAlt: |
   Service errors overview inside a Bugsnag plugin.
 
+availableOnRoadie: true
+roadieDocsPath: /bugsnag/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/buildkite.md
+++ b/content/backstage/plugins/buildkite.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/buildkite/buildkite-logo.png'
 coverImage: '../../assets/buildkite-plugin-overview.png'
 coverImageAlt: 'A list of builds in a table along with a status and retry button for each build.'
 
+availableOnRoadie: true
+roadieDocsPath: /buildkite/
+
 gettingStarted:
   - intro: Install the plugin
     language: bash

--- a/content/backstage/plugins/catalog-graph.md
+++ b/content/backstage/plugins/catalog-graph.md
@@ -15,6 +15,9 @@ logoImage: '../../assets/logos/catalog-graph/catalog-graph-logo.jpeg'
 coverImage: '../../assets/catalog-graph-plugin.png'
 coverImageAlt: 'Backstage Catalog Graph Plugin showing relationships between entities'
 
+availableOnRoadie: true
+roadieDocsPath: /catalog-graph/
+
 gettingStarted:
   - intro: Install the [plugin](https://github.com/backstage/backstage/blob/master/plugins/catalog-graph/README.md) into Backstage.
     language: bash

--- a/content/backstage/plugins/circle-ci.md
+++ b/content/backstage/plugins/circle-ci.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/circle-ci/circle-ci-logo-only-black.png'
 coverImage: '../../assets/circle-ci-plugin.jpg'
 coverImageAlt: 'A list of builds in a table along with a status and retry button for each build.'
 
+availableOnRoadie: true
+roadieDocsPath: /circleci/
+
 gettingStarted:
   # What will this step accomplish?
   - intro: Install the plugin

--- a/content/backstage/plugins/datadog.md
+++ b/content/backstage/plugins/datadog.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/datadog/datadog-logo-no-text.png'
 coverImage: '../../assets/datadog-plugin.png'
 coverImageAlt: 'A screenshot of the Datadog plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /datadog/
+
 gettingStarted:
   - intro: With this plugin, you can embed Datadog graphs and dashboards into your instance of Backstage. Datadog is a monitoring service for cloud-scale applications, providing monitoring of servers, databases, tools, and services through a SaaS-based data analytics platform.
 

--- a/content/backstage/plugins/firehydrant.md
+++ b/content/backstage/plugins/firehydrant.md
@@ -16,6 +16,9 @@ logoImage: '../../assets/logos/firehydrant/firehydrant.png'
 coverImage: '../../assets/backstage/plugins/firehydrant/firehydrant-service-card.png'
 coverImageAlt: 'FireHydrant in Backstage'
 
+availableOnRoadie: true
+roadieDocsPath: /firehydrant/
+
 gettingStarted:
   - intro: Install the front-end plugin.
     language: bash

--- a/content/backstage/plugins/github-actions.md
+++ b/content/backstage/plugins/github-actions.md
@@ -17,6 +17,8 @@ logoImage: '../../assets/logos/github/mark/official/PNG/GitHub-Mark-120px-plus.p
 coverImage: '../../assets/backstage/plugins/github-actions/cover.png'
 coverImageAlt: 'A list of builds for the Spotify Backstage repo with status and retry buttons.'
 
+availableOnRoadie: true
+
 gettingStarted: # What will this step accomplish?
   - intro: |
       If you are **using Roadie**, or you are using a GitHub app with self-hosted Backstage, OAuth

--- a/content/backstage/plugins/github-insights.md
+++ b/content/backstage/plugins/github-insights.md
@@ -16,6 +16,8 @@ logoImage: '../../assets/logos/code-insights/code-icon.png'
 coverImage: '../../assets/code-insights-plugin.png'
 coverImageAlt: 'A screenshot of the GitHub Insights plugin. It is showing a code details for a sample component.'
 
+availableOnRoadie: true
+
 gettingStarted: # What will this step accomplish?
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/github-pull-requests.md
+++ b/content/backstage/plugins/github-pull-requests.md
@@ -19,6 +19,8 @@ coverImageAlt: |
   Pull requests for Backstage rendered inside a Backstage plugin.
   The statistics widget is alongside, showing the average time to merge a PR.
 
+availableOnRoadie: true
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/jenkins.md
+++ b/content/backstage/plugins/jenkins.md
@@ -15,6 +15,9 @@ logoImage: '../../assets/logos/jenkins/logo-jenkins.png'
 coverImage: '../../assets/backstage/plugins/jenkins/jenkins-plugin.png'
 coverImageAlt: 'A screenshot of the Jenkins plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /jenkins/
+
 gettingStarted:
   - intro: Install the plugin.
     language: bash

--- a/content/backstage/plugins/jira.md
+++ b/content/backstage/plugins/jira.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/jira/jira_logo.png'
 coverImage: '../../assets/jira-plugin.png'
 coverImageAlt: 'A preview of Jira plugin including tasks summary, project information and Activity Stream.'
 
+availableOnRoadie: true
+roadieDocsPath: /jira/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/kubernetes.md
+++ b/content/backstage/plugins/kubernetes.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/kubernetes/logo-kubernetes.png'
 coverImage: '../../assets/kubernetes-plugin.png'
 coverImageAlt: 'A screenshot of the Kubernetes plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /kubernetes/
+
 gettingStarted:
   - intro: The Kubernetes plugin is made up of @backstage/plugin-kubernetes and @backstage/plugin-kubernetes-backend. To make it work, you will need to install and configure them.
 

--- a/content/backstage/plugins/lighthouse.md
+++ b/content/backstage/plugins/lighthouse.md
@@ -15,6 +15,9 @@ logoImage: '../../assets/logos/lighthouse/logo-lh.png'
 coverImage: '../../assets/lighthouse-plugin.jpg'
 coverImageAlt: 'A screenshot of the Lighthouse plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /lighthouse/
+
 gettingStarted:
   - intro: Before you start please make sure that you setup lighthouse-audit-service first.
 

--- a/content/backstage/plugins/newrelic.md
+++ b/content/backstage/plugins/newrelic.md
@@ -16,6 +16,9 @@ logoImage: '../../assets/logos/new-relic/logo-relic.png'
 coverImage: '../../assets/new-relic-plugin.png'
 coverImageAlt: 'A screenshot of the GCP Projects plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /newrelic/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/opsgenie.md
+++ b/content/backstage/plugins/opsgenie.md
@@ -15,6 +15,9 @@ logoImage: '../../assets/logos/opsgenie/logo-opsgenie.png'
 coverImage: '../../assets/backstage/plugins/opsgenie/opsgenie-plugin.png'
 coverImageAlt: 'A screenshot of the OpsGenie plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /opsgenie/
+
 gettingStarted:
   - intro: Install the plugin.
     language: bash

--- a/content/backstage/plugins/pagerduty.md
+++ b/content/backstage/plugins/pagerduty.md
@@ -16,6 +16,9 @@ logoImage: '../../assets/logos/pagerduty/pagerduty-logo-light-200x200.png'
 coverImage: '../../assets/pagerduty-plugin-2077x955.png'
 coverImageAlt: 'PagerDuty incidents for sample-service-1 rendered in Backstage.'
 
+availableOnRoadie: true
+roadieDocsPath: /pagerduty/
+
 gettingStarted:
   - intro: The PagerDuty plugin is a frontend plugin. You will need to install it, configure it and add it to an appropriate location on the entity page.
 

--- a/content/backstage/plugins/prometheus.md
+++ b/content/backstage/plugins/prometheus.md
@@ -16,7 +16,8 @@ logoImage: '../../assets/prometheus/prom_logo.png'
 coverImage: '../../assets/prometheus/prom_entity_content.png'
 coverImageAlt: 'Prometheus alerts and graphs rendered in Backstage.'
 
-
+availableOnRoadie: true
+roadieDocsPath: /prometheus/
 
 gettingStarted:
   - intro: The Prometheus plugin is a frontend plugin. You will need to install it, configure it and add it to an appropriate location on the entity page.

--- a/content/backstage/plugins/rootly.md
+++ b/content/backstage/plugins/rootly.md
@@ -1,6 +1,6 @@
 ---
 humanName: Rootly
-heading: Rootly Backstage Plugin
+heading: Backstage Rootly Plugin
 publishedDate: '2022-08-27T21:00:00.0Z'
 lead: Manage incidents directly from Slack
 attribution:
@@ -12,6 +12,9 @@ seo:
   description: 'See Rootly data and incidents directly inside Backstage.'
 
 logoImage: '../../assets/logos/rootly/logo.png'
+
+availableOnRoadie: true
+roadieDocsPath: /rootly/
 
 gettingStarted:
   - intro: Create a Rootly API Key. Use the steps further down in the document to do this.

--- a/content/backstage/plugins/sentry.md
+++ b/content/backstage/plugins/sentry.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/sentry/sentry-glyph-dark.png'
 coverImage: '../../assets/sentry-plugin-1604x716.png'
 coverImageAlt: 'A screenshot of the Sentry plugin. It is showing a list of errors.'
 
+availableOnRoadie: true
+roadieDocsPath: /sentry/
+
 gettingStarted:
   - intro: 'Install the plugin package in your Backstage app'
     language: 'bash'

--- a/content/backstage/plugins/shortcut.md
+++ b/content/backstage/plugins/shortcut.md
@@ -16,6 +16,9 @@ coverImage: '../../assets/backstage/plugins/shortcut/shortcut.png'
 coverImageAlt: |
   Stories overview in Shortcut plugin.
 
+availableOnRoadie: true
+roadieDocsPath: /shortcut-plugin/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/sonarqube.md
+++ b/content/backstage/plugins/sonarqube.md
@@ -16,6 +16,9 @@ logoImage: '../../assets/logos/sonarqube/logo-sonar.png'
 coverImage: '../../assets/sonar-plugin.png'
 coverImageAlt: 'A screenshot of the SonarQube and SonarCloud plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /snyk/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/tech-insights.md
+++ b/content/backstage/plugins/tech-insights.md
@@ -16,7 +16,7 @@ logoImage: '../../assets/tech-insights/tech_insights.png'
 coverImage: '../../assets/tech-insights/tech_insights_scorecard.png'
 coverImageAlt: "Visualize, understand and optimize your team's tech health."
 
-
+availableOnRoadie: true
 
 gettingStarted:
   - intro: 'Install the plugin backend packages Backstage backend app'

--- a/content/backstage/plugins/tech-radar.md
+++ b/content/backstage/plugins/tech-radar.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/tech-radar/radar.png'
 coverImage: '../../assets/tech-radar-plugin.jpg'
 coverImageAlt: 'A screenshot of the Tech Radar plugin.'
 
+availableOnRoadie: true
+roadieDocsPath: /tech-radar/
+
 gettingStarted:
   - intro: Install the plugin into Backstage.
     language: bash

--- a/content/backstage/plugins/travis-ci.md
+++ b/content/backstage/plugins/travis-ci.md
@@ -17,6 +17,9 @@ logoImage: '../../assets/logos/travis-ci/travis-ci-mascot-200x200.png'
 coverImage: '../../assets/travis-ci-plugin-1642x1027.png'
 coverImageAlt: 'A screenshot of the Travis CI plugin. It is showing a list of builds for a sample service.'
 
+availableOnRoadie: true
+roadieDocsPath: /travis-ci/
+
 gettingStarted:
   - intro: 'In the `backstage/packages/app` project add the plugin as a `package.json` dependency:'
     language: 'bash'

--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -1,11 +1,18 @@
 import React from 'react';
+import classnames from 'classnames';
 
-const Chip = ({ label }) => (
-  <span
-    className="bg-primary-100 text-primary-800 inline-flex items-center px-3 py-0.5 rounded-full text-sm font-medium mr-2"
-  >
-    {label}
-  </span>
-);
+const Chip = ({ label, color = 'orange' }) => {
+  const defaultClasses = 'inline-flex items-center px-3 py-0.5 rounded-full text-sm font-medium mr-2';
+
+  let colorClasses;
+  if (color === 'orange') colorClasses = 'bg-primary-100 text-primary-800';
+  if (color === 'green') colorClasses = 'bg-green-200 text-gray-800 border-2 border-green-800';
+
+  return (
+    <span className={classnames(defaultClasses, colorClasses)}>
+      {label}
+    </span>
+  );
+};
 
 export default Chip;

--- a/src/components/backstage/plugins/Header.js
+++ b/src/components/backstage/plugins/Header.js
@@ -1,8 +1,21 @@
 import React from 'react';
-import { Lead, Headline } from 'components';
+import { Lead, Headline, Link, Chip } from 'components';
 
 import Logo from './Logo';
 import Attribution from './Attribution';
+
+
+const RoadieDocsChip = ({ availableOnRoadie, roadieDocsPath }) => {
+  if (!availableOnRoadie) return null;
+
+  const chip = <Chip label="Available on Roadie" color="green" />;
+  if (!roadieDocsPath) return chip;
+  return (
+    <Link to={`/docs/integrations${roadieDocsPath}`} className="inline-block">
+      {chip}
+    </Link>
+  );
+};
 
 const Header = ({
   plugin: {
@@ -13,6 +26,8 @@ const Header = ({
       lead,
       attribution,
       intro,
+      availableOnRoadie,
+      roadieDocsPath,
     },
   },
 }) => (
@@ -24,7 +39,11 @@ const Header = ({
     <div className="mb-4">
       <Lead>{lead}</Lead>
     </div>
-    <Attribution attribution={attribution} />
+
+    <div className="mb-4">
+      <Attribution attribution={attribution} />
+    </div>
+
     {intro &&
       <div className="mb-4 mt-8 text-center">
         <p className="prose prose-primary mr-auto ml-auto">
@@ -32,6 +51,8 @@ const Header = ({
         </p>
       </div>
     }
+
+    <RoadieDocsChip availableOnRoadie={availableOnRoadie} roadieDocsPath={roadieDocsPath} />
   </header>
 );
 

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -52,7 +52,7 @@ const PluginTemplate = ({ data }) => {
 
           <ResponsiveSpacer>
             <div className="text-center pb-3">
-              <Title text="Getting started is simple" />
+              <Title text="Get SaaS Backstage" />
             </div>
 
             <div className="prose prose-primary max-w-none">
@@ -66,7 +66,7 @@ const PluginTemplate = ({ data }) => {
           {plugin.frontmatter.gettingStarted && (
             <ResponsiveSpacer>
               <div className="text-center pb-3" >
-                <Title text="Installation steps" />
+                <Title text="Self-hosted Backstage installation steps" />
               </div>
 
               {plugin.frontmatter.gettingStarted.map((section, index) =>
@@ -162,6 +162,8 @@ export const pageQuery = graphql`
         lead
         heading
         intro
+        availableOnRoadie
+        roadieDocsPath
 
         attribution {
           href

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,7 @@ module.exports = {
       gray: colors.neutral,
       primary: colors.orange,
       info: colors.violet,
+      green: colors.green,
       white: '#fff',
     },
 


### PR DESCRIPTION
The idea is to try to help Roadie customers who accidentally going to the wrong plugin directory.

Preview link: https://deploy-preview-897--roadie.netlify.app/backstage/plugins/argo-cd/

![Screenshot 2022-11-29 at 20 55 26](https://user-images.githubusercontent.com/562403/204645764-cb9cea91-f53d-4f43-857a-d192ead74905.png)
