### PR TITLE
Add more details to s3 setup docs specifying role naming restriction

### DIFF
--- a/content/docs/integrations/aws-s3/index.md
+++ b/content/docs/integrations/aws-s3/index.md
@@ -24,6 +24,8 @@ Navigate to `Administration > Settings > AWS S3` and make a note of the Roadie b
 
 Follow the steps [here](/docs/details/accessing-aws-resources) to create the role. 
 
+The role needs to follow this naming convention `arn:aws:iam::*:role/<your-tenant-name>-roadie-read-only-role` where <your-tenant-name> matches your organisation's name used in the url of your Roadie instance.
+
 You'll need to attach a policy which allows access to the required S3 buckets such as `AmazonS3ReadOnlyAccess`. This policy grants roadie read access to all buckets. 
 If you do not want to grant this access you can [create your own policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create-console.html) 
 which restricts access to only certain buckets. e.g. 


### PR DESCRIPTION
https://app.shortcut.com/larder/story/12388/tibber-openapi-spec-ingestion-from-s3-auth-issue