### PR TITLE
Use builtin trailingSlash config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,6 +76,8 @@ module.exports = {
     },
   },
 
+  trailingSlash: 'always',
+
   plugins: [
     {
       resolve: `gatsby-source-filesystem`,
@@ -173,7 +175,6 @@ module.exports = {
       },
     },
 
-    `gatsby-plugin-force-trailing-slashes`,
     'gatsby-plugin-twitter',
     'gatsby-plugin-netlify',
     'gatsby-plugin-image',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gatsby-plugin-algolia": "^0.25.0",
     "gatsby-plugin-csp": "^1.1.3",
     "gatsby-plugin-feed": "^4.4.0",
-    "gatsby-plugin-force-trailing-slashes": "^1.0.5",
     "gatsby-plugin-google-analytics": "^4.4.0",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-google-tagmanager": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,13 +1267,6 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@7.12.5":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
-  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@7.14.0":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
@@ -6749,13 +6742,6 @@ gatsby-plugin-feed@^4.4.0:
     gatsby-plugin-utils "^3.19.0"
     lodash.merge "^4.6.2"
     rss "^1.2.2"
-
-gatsby-plugin-force-trailing-slashes@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-force-trailing-slashes/-/gatsby-plugin-force-trailing-slashes-1.0.6.tgz#f170b5919e16e2dca52689b5430688e92bf1895e"
-  integrity sha512-fFkgLqcu0AvFiwLe/Do/pZB+k2jYx6FfHFUgPvoD2PpxSDwyUR8CONZKlhmtuJ6foaaFSsD+vvmRWhfLqpAECQ==
-  dependencies:
-    "@babel/runtime" "7.12.5"
 
 gatsby-plugin-google-analytics@^4.4.0:
   version "4.25.0"


### PR DESCRIPTION
[The plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-force-trailing-slashes/) we were previously using to redirect non-trailing-slash URLs to trailing-slash URLs is deprecated. It should be replaced with the [trailingSlash config option](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash).