### PR TITLE
Use latest version for local techdocs 

### DIFF
--- a/content/docs/getting-started/technical-documentation/index.md
+++ b/content/docs/getting-started/technical-documentation/index.md
@@ -96,17 +96,16 @@ You can generate / serve your docs locally to view what they would look like whe
 To generate the docs to the site directory of the project you can run the following command:
 
 ```bash
-npx @techdocs/cli@1.2.0 generate --docker-image roadiehq/techdocs
+npx @techdocs/cli generate --docker-image roadiehq/techdocs
 ```
 
 To start a local server at port 3000 containing the generated docs, you can run the following command:
 ```bash
-npx @techdocs/cli@1.2.0 serve --docker-image roadiehq/techdocs
+npx @techdocs/cli serve --docker-image roadiehq/techdocs
 ```
 
 NB: We have seen some issues generating and serving plantuml and mermaid diagrams sometimes on M1 Macbooks due to unresolved 
-bugs in open source dependencies. Please reach out to us anyway if you run into any difficulties. 
-NB: We need to pin to an earlier version until [this bug](https://github.com/backstage/backstage/issues/13813) in @techdocs/cli@1.2.1 is fixed in the Open Source project.
+bugs in open source dependencies. Please reach out to us anyway if you run into any difficulties.
 
 ### Step 5: Publish your documentation
 


### PR DESCRIPTION
The version we had pinned is not working now for some reason. And the bug that had stopped us using the latest version is fixed.