### PR TITLE
Add warning to the custom plugin steps

### DIFF
--- a/content/docs/custom-plugins/configuring/index.md
+++ b/content/docs/custom-plugins/configuring/index.md
@@ -16,10 +16,8 @@ Contact us to have the custom plugins feature enabled for your Roadie instance.
 
 ## Configuring a plugin for your Roadie instance
 
-:::warning Important
-Please follow these steps in the order specified
-:::
-
+> **Warning**
+> Please follow these steps in the order specified
 
 ### Step 1. Create plugin definition in Roadie
 

--- a/content/docs/custom-plugins/configuring/index.md
+++ b/content/docs/custom-plugins/configuring/index.md
@@ -16,6 +16,11 @@ Contact us to have the custom plugins feature enabled for your Roadie instance.
 
 ## Configuring a plugin for your Roadie instance
 
+:::warning Important
+Please follow these steps in the order specified
+:::
+
+
 ### Step 1. Create plugin definition in Roadie
 
 You can navigate to h<gatsbyhack>tt</gatsbyhack>ps://your-company.roadie.so/administration/custom-plugins where you will find a collection of cards detailing custom plugins configured for the Roadie instance.


### PR DESCRIPTION
These steps need to be follow in that specific order but this order doesn't look so logical so better to warn that this is important.