### PR TITLE
Plugins nav

### DIFF
--- a/content/backstage/plugins/argo-cd.md
+++ b/content/backstage/plugins/argo-cd.md
@@ -73,7 +73,7 @@ gettingStarted:
       ARGOCD_AUTH_TOKEN='argocd.token=<token>'
 ---
 
-## Support for multiple ArgoCD instances - Option 1
+### Support for multiple ArgoCD instances - Option 1
 
 If you want to create multiple components that fetch data from different argoCD instances, you have to add a proxy config for each instance:
 
@@ -108,7 +108,7 @@ argocd/proxy-url: '/argocd/api2'
 
 `argocd/proxy-url` annotation defaults to '/argocd/api' so it's not needed if there is only one proxy config.
 
-## Support for multiple Argo CD instances - Option 2 - Argo CD backend plugin
+### Support for multiple Argo CD instances - Option 2 - Argo CD backend plugin
 
 
 To enable ArgoCD backend plugin you need to import it to your backend application. 

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -5,7 +5,7 @@ import kebabCase from 'lodash/kebabCase';
 const CodeBlock = ({ language, code, intro }) => (
   <div>
     {intro && intro !== '' && (
-      <div className="prose prose-primary" dangerouslySetInnerHTML={{ __html: intro.trim() }} />
+      <div className="prose-xl prose-primary" dangerouslySetInnerHTML={{ __html: intro.trim() }} />
     )}
 
     {code && code !== '' && (

--- a/src/components/backstage/plugins/Attribution.js
+++ b/src/components/backstage/plugins/Attribution.js
@@ -1,26 +1,25 @@
 import React from 'react';
 import Link from 'components/TextLink';
+import classnames from 'classnames';
 
-const Attribution = ({ attribution }) => {
+const Attribution = ({ attribution, className }) => {
   if (!attribution) return null;
 
   if (!attribution.href || attribution.href === '') {
     return (
-      <div className="text-base">
-        <p>Created by {attribution.text}</p>
-      </div>
+      <p className={classnames('text-base', className)}>
+        Created by {attribution.text}
+      </p>
     );
   }
 
   return (
-    <div className="text-base">
-      <p>
-        Created by{' '}
-        <Link to={attribution.href} color="primary">
-          {attribution.text}
-        </Link>
-      </p>
-    </div>
+    <p className={classnames('text-base', className)}>
+      Created by{' '}
+      <Link to={attribution.href} color="primary">
+        {attribution.text}
+      </Link>
+    </p>
   );
 };
 

--- a/src/components/backstage/plugins/Header.js
+++ b/src/components/backstage/plugins/Header.js
@@ -4,7 +4,6 @@ import { Lead, Headline, Link, Chip } from 'components';
 import Logo from './Logo';
 import Attribution from './Attribution';
 
-
 const RoadieDocsChip = ({ availableOnRoadie, roadieDocsPath }) => {
   if (!availableOnRoadie) return null;
 
@@ -31,29 +30,31 @@ const Header = ({
     },
   },
 }) => (
-  <header className="text-center pb-4 mb-4 md:pt-8 md:pb-24 border-b-2 border-gray-100">
-    <Logo sharpImage={logoImage.childImageSharp} alt={`${humanName} logo`} />
-    <div className="mb-4">
-      <Headline>{heading}</Headline>
+  <>
+    <div className="mx-auto max-w-7xl px-4 py-10">
+      <Link to="/backstage/plugins/" className="font-bold text-blueroadie">
+        <span className="text-orange-500">←</span> Backstage Plugins Guides
+      </Link>
     </div>
-    <div className="mb-4">
-      <Lead>{lead}</Lead>
-    </div>
-
-    <div className="mb-4">
-      <Attribution attribution={attribution} />
-    </div>
-
-    {intro &&
-      <div className="mb-4 mt-8 text-center">
-        <p className="prose prose-primary mr-auto ml-auto">
-          {intro}
-        </p>
+    <header className="bg-white mx-auto max-w-7xl mb-5 px-4 py-10 text-center lg:text-left xl:rounded-lg lg:flex lg:px-0 lg:mb-10 items-center">
+      <div className="lg:w-1/4 mt-5 lg:mt-0">
+        <Logo sharpImage={logoImage.childImageSharp} alt={`${humanName} logo`} />
       </div>
-    }
+      <div>
+        <Headline className="mb-4">{heading}</Headline>
+        <Lead className="mb-4 text-blueroadie">{lead}</Lead>
+        <Attribution attribution={attribution} className="mb-4" />
 
-    <RoadieDocsChip availableOnRoadie={availableOnRoadie} roadieDocsPath={roadieDocsPath} />
-  </header>
+        {intro && (
+          <div className="mb-4 mt-8">
+            {intro}
+          </div>
+        )}
+
+        <RoadieDocsChip availableOnRoadie={availableOnRoadie} roadieDocsPath={roadieDocsPath} />
+      </div>
+    </header>
+  </>
 );
 
 export default Header;

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -44,16 +44,17 @@ const PluginTemplate = ({ data }) => {
       <Header plugin={plugin} />
       <main className="pt-4 pb-8 px-4 lg:pb-28">
         <div className="relative max-w-lg mx-auto lg:max-w-4xl">
-          <nav className="invisible lg:visible mb-8 flex flex-wrap text-center border-b-2 border-blueroadie">
+          <nav className="invisible lg:visible pb-4 mb-8 flex flex-wrap text-center border-b-2 border-blueroadie">
             <span className="inline-block py-4 text-blueroadie font-bold">Installation steps:</span>
-            <span className="inline-block p-4 ml-8 text-white font-bold bg-blueroadie rounded-t-lg active">
+            <span className="inline-block p-4 ml-8 text-white font-bold bg-blueroadie rounded-lg active">
               Self-hosted Backstage
             </span>
             {plugin.frontmatter.roadieDocsPath && (
               <a
                 href={`/docs/integrations${plugin.frontmatter.roadieDocsPath}`}
                 target="_blank"
-                className="inline-block p-4 ml-4 bg-gray-100 text-blueroadie font-bold rounded-t-lg hover:bg-gray-100 hover:text-orange-600 flex align-center"
+                rel="noreferrer"
+                className="inline-block p-4 ml-4 bg-gray-100 text-blueroadie font-bold rounded-lg hover:bg-gray-100 hover:text-orange-600 flex align-center"
               >
                 No-code via Roadie <ExternalLinkIcon className='inline-block w-4 ml-2' />
               </a>

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -3,6 +3,7 @@ import Prism from 'prismjs';
 import { graphql } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import {
+  Button,
   TextLink as Link,
   Title,
   CodeBlock,
@@ -18,7 +19,10 @@ import {
 } from 'components/CallToAction/SubscribeToNewsletter';
 
 const PluginTemplate = ({ data }) => {
-  const { plugin, site: { siteMetadata } } = data;
+  const {
+    plugin,
+    site: { siteMetadata },
+  } = data;
 
   const [email, setEmail] = useState('');
   const [modalOpen, setModalOpen] = useState(false);
@@ -45,30 +49,26 @@ const PluginTemplate = ({ data }) => {
 
       <SitewideHeader />
 
-      <main className="pt-4 pb-8 px-4 lg:pt-8 lg:pb-28">
-        <div className="relative max-w-lg mx-auto lg:max-w-3xl">
-
-          <Header plugin={plugin} />
-
-          <ResponsiveSpacer>
-            <div className="text-center pb-3">
-              <Title text="Get SaaS Backstage" />
-            </div>
-
-            <div className="prose prose-primary max-w-none">
-              <p>
-                Don&apos;t want to spend your time installing and upgrading Backstage plugins?{' '}
-                <Link to="/free-trial/" color="primary">Get managed Backstage</Link> from Roadie.
-              </p>
-            </div>
-          </ResponsiveSpacer>
+      <Header plugin={plugin} />
+      <main className="pt-4 pb-8 px-4 lg:pb-28">
+        <div className="relative max-w-lg mx-auto lg:max-w-4xl">
+          <nav className="invisible lg:visible mb-8 flex flex-wrap text-center border-b-2 border-blueroadie">
+            <span className="inline-block py-4 text-blueroadie font-bold">Installation steps:</span>
+            <span className="inline-block p-4 ml-8 text-white font-bold bg-blueroadie rounded-t-lg active">
+              Self-hosted Backstage
+            </span>
+            {plugin.frontmatter.roadieDocsPath && (
+              <Link
+                to={`/docs/integrations${plugin.frontmatter.roadieDocsPath}`}
+                className="inline-block p-4 ml-4 bg-gray-100 text-blueroadie font-bold rounded-t-lg hover:bg-gray-100 hover:text-orange-600"
+              >
+                No-code via Roadie
+              </Link>
+            )}
+          </nav>
 
           {plugin.frontmatter.gettingStarted && (
-            <ResponsiveSpacer>
-              <div className="text-center pb-3" >
-                <Title text="Self-hosted Backstage installation steps" />
-              </div>
-
+            <>
               {plugin.frontmatter.gettingStarted.map((section) => {
                 const key = CodeBlock.generateKey(section);
 
@@ -78,7 +78,7 @@ const PluginTemplate = ({ data }) => {
                       <Title text={section.title} />
                     </div>
                   );
-                } 
+                }
 
                 return (
                   <CodeBlock
@@ -89,22 +89,29 @@ const PluginTemplate = ({ data }) => {
                   />
                 );
               })}
-            </ResponsiveSpacer>
+            </>
           )}
 
-          <ResponsiveSpacer>
-            <div className="prose prose-primary">
-              <p>
-                Found a mistake? <EditOnGitHubLink siteMetadata={siteMetadata} plugin={plugin} />.
-              </p>
-            </div>
-          </ResponsiveSpacer>
+          <p className="prose prose-primary my-10">
+            Found a mistake? <EditOnGitHubLink siteMetadata={siteMetadata} plugin={plugin} />.
+          </p>
+
+          <div className="border-4 border-orange-500 font-bold p-8 text-xl rounded-lg mb-10">
+            <p className="mb-4">
+              Don&apos;t want to spend your time installing and manually upgrading each Backstage
+              plugin?
+            </p>
+            <Button
+              link={true}
+              color="primary"
+              to={'/free-trial/'}
+              text={'Get managed Backstage'}
+            />
+          </div>
 
           {plugin.frontmatter.coverImage && (
-            <ResponsiveSpacer>
-              <div className="text-center pb-3">
-                <Title text="How it looks" />
-              </div>
+            <>
+              <Title text="How it looks" className="mb-10 border-b-2" />
 
               <div>
                 <GatsbyImage
@@ -113,31 +120,23 @@ const PluginTemplate = ({ data }) => {
                   className="max-w-full max-h-full shadow-small"
                 />
               </div>
-            </ResponsiveSpacer>
+            </>
           )}
 
           {plugin.notes && plugin.notes !== '' && (
-            <ResponsiveSpacer>
-              <div>
-                <div className="text-center pb-3">
-                  <Title text="Things to know" />
-                </div>
+            <>
+              <Title text="Things to know" className="mb-10 mt-20 border-b-2" />
 
-                <div
-                  className="prose prose-primary max-w-none"
-                  dangerouslySetInnerHTML={{ __html: plugin.notes }}
-                />
-              </div>
-            </ResponsiveSpacer>
+              <div
+                className="prose-xl prose-primary max-w-none"
+                dangerouslySetInnerHTML={{ __html: plugin.notes }}
+              />
+            </>
           )}
         </div>
 
         <div className="relative max-w-lg mx-auto lg:max-w-xl mt-24">
-          <SubscribeToNewsletterCTA
-            setModalOpen={setModalOpen}
-            email={email}
-            setEmail={setEmail}
-          />
+          <SubscribeToNewsletterCTA setModalOpen={setModalOpen} email={email} setEmail={setEmail} />
         </div>
       </main>
 

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -2,20 +2,13 @@ import React, { useEffect, useState } from 'react';
 import Prism from 'prismjs';
 import { graphql } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
-import {
-  Button,
-  TextLink as Link,
-  Title,
-  CodeBlock,
-  SEO,
-  SitewideHeader,
-  SitewideFooter,
-} from 'components';
+import { Button, Title, CodeBlock, SEO, SitewideHeader, SitewideFooter } from 'components';
 import { EditOnGitHubLink, Header } from 'components/backstage/plugins';
 import {
   SubscribeToNewsletterSuccessModal,
   SubscribeToNewsletterCTA,
 } from 'components/CallToAction/SubscribeToNewsletter';
+import { ExternalLinkIcon } from '@heroicons/react/outline';
 
 const PluginTemplate = ({ data }) => {
   const {
@@ -57,12 +50,13 @@ const PluginTemplate = ({ data }) => {
               Self-hosted Backstage
             </span>
             {plugin.frontmatter.roadieDocsPath && (
-              <Link
-                to={`/docs/integrations${plugin.frontmatter.roadieDocsPath}`}
-                className="inline-block p-4 ml-4 bg-gray-100 text-blueroadie font-bold rounded-t-lg hover:bg-gray-100 hover:text-orange-600"
+              <a
+                href={`/docs/integrations${plugin.frontmatter.roadieDocsPath}`}
+                target="_blank"
+                className="inline-block p-4 ml-4 bg-gray-100 text-blueroadie font-bold rounded-t-lg hover:bg-gray-100 hover:text-orange-600 flex align-center"
               >
-                No-code via Roadie
-              </Link>
+                No-code via Roadie <ExternalLinkIcon className='inline-block w-4 ml-2' />
+              </a>
             )}
           </nav>
 

--- a/src/templates/Plugin.js
+++ b/src/templates/Plugin.js
@@ -8,7 +8,6 @@ import {
   Title,
   CodeBlock,
   SEO,
-  ResponsiveSpacer,
   SitewideHeader,
   SitewideFooter,
 } from 'components';


### PR DESCRIPTION
## Motivation

The marketplace is one of our most significant sources of traffic from SEs, but the individual pages don't have any links to other pages or a clear CTA.

## Approach

In this first iteration, I'm adding navigation to the plugin page and improving the design of the CTA, and other small details. 

## Screenshots
 
![Screenshot 2023-03-22 at 17 05 51](https://user-images.githubusercontent.com/4451393/226968093-d199102b-969b-4095-987c-26e4e3c61eb0.png)
![Screenshot 2023-03-22 at 17 06 01](https://user-images.githubusercontent.com/4451393/226968268-c320c630-4fa4-4d15-8cb7-01b452131ba9.png)

## Future work

I want to add related content to the most significant entries, for example the ArgoCD one
 

