### PR TITLE
Add attribution field

### DIFF
--- a/cypress/integration/free_trial_page.js
+++ b/cypress/integration/free_trial_page.js
@@ -11,6 +11,7 @@ describe('The free trial page', () => {
 
     cy.get('#get-instance-email-input').type('test@example.com');
     cy.get('#scm').select('GitHub On-prem');
+    cy.get('#reported-attribution').type('Newsletter');
     cy.get('button[data-testid="agree-to-policies"]').click();
     cy.contains('Request a trial').click();
     cy.contains('Thank you for requesting a free trial of Roadie Backstage');

--- a/cypress/integration/landing_page_spec.js
+++ b/cypress/integration/landing_page_spec.js
@@ -12,6 +12,7 @@ describe('The landing page', () => {
 
     cy.get('#request-demo-name-input').type('Mary Mac');
     cy.get('#request-demo-email-input').type('test@example.com');
+    cy.get('#reported-attribution').type('Newsletter');
     cy.get('button[data-testid="sub-to-newsletter"]').click();
     cy.get('button').contains('Request a demo').click();
     cy.contains("We'll be in touch");

--- a/src/components/CallToAction/ExtendedGetInstanceCallToAction.js
+++ b/src/components/CallToAction/ExtendedGetInstanceCallToAction.js
@@ -3,6 +3,7 @@ import {
   Link,
   Switch,
   Button,
+  TextField,
   EmailField,
   SubscribeToNewsletterSwitch,
   Form,
@@ -16,6 +17,7 @@ import { currentlyExecutingGitBranch, recaptchaEnabled } from '../../environment
 const submitToNetlifyForms = async ({
   email,
   scmTool,
+  attribution,
   subToNewsletter,
   netlifyFormName,
   agreeToPolicies,
@@ -28,6 +30,7 @@ const submitToNetlifyForms = async ({
   const formData = new FormData();
   formData.append('form-name', netlifyFormName);
   formData.append('email', email);
+  formData.append('reported-attribution', attribution);
   formData.append('scm', scmTool.value);
   formData.append('sub-to-newsletter', subToNewsletter);
   formData.append(HONEYPOT_FIELD_NAME, honeypotText);
@@ -59,6 +62,7 @@ const ExtendedGetInstanceCallToAction = ({
   scmTool,
   setScmTool,
 }) => {
+  const [attribution, setAttribution] = useState('');
   const [subToNewsletter, setSubToNewsletter] = useState(true);
   const [agreed, setAgreed] = useState(false);
   const [honeypotText, setHoneypotText] = useState('');
@@ -70,6 +74,7 @@ const ExtendedGetInstanceCallToAction = ({
 
   const clearForm = () => {
     setEmailValues({ email: '' });
+    setAttribution('');
     setAgreed(false);
   };
 
@@ -86,6 +91,7 @@ const ExtendedGetInstanceCallToAction = ({
     const resp = await submitToNetlifyForms({
       email: emailValues.email,
       scmTool,
+      attribution,
       subToNewsletter,
       agreeToPolicies: agreed,
       netlifyFormName,
@@ -134,6 +140,16 @@ const ExtendedGetInstanceCallToAction = ({
           color="primary"
         />
       </div>
+
+      <TextField
+        label="How did you hear about Roadie?"
+        type="text"
+        name="reported-attribution"
+        id="reported-attribution"
+        onChange={setAttribution}
+        value={attribution}
+        fullWidth
+      />
 
       <SubscribeToNewsletterSwitch checked={subToNewsletter} onChange={setSubToNewsletter} />
 

--- a/src/components/CallToAction/RequestDemoCallToAction.js
+++ b/src/components/CallToAction/RequestDemoCallToAction.js
@@ -17,6 +17,7 @@ const submitToNetlifyForms = async ({
   name,
   email,
   scmTool,
+  attribution,
   subToNewsletter,
   honeypotText,
   netlifyFormName,
@@ -29,6 +30,7 @@ const submitToNetlifyForms = async ({
   formData.append('form-name', netlifyFormName);
   formData.append('name', name);
   formData.append('email', email);
+  formData.append('reported-attribution', attribution);
   formData.append('scm', scmTool.value);
   formData.append('sub-to-newsletter', subToNewsletter);
   formData.append(HONEYPOT_FIELD_NAME, honeypotText);
@@ -60,6 +62,7 @@ const RequestDemoCallToAction = ({ onSuccess, location, scmTool, setScmTool }) =
     email: emailFromUrl,
   });
   const [name, setName] = useState('');
+  const [attribution, setAttribution] = useState('');
   const [subToNewsletter, setSubToNewsletter] = useState(true);
   const [honeypotText, setHoneypotText] = useState('');
   const [recaptchaResponse, setRecaptchaResponse] = useState('');
@@ -70,6 +73,7 @@ const RequestDemoCallToAction = ({ onSuccess, location, scmTool, setScmTool }) =
 
   const clearForm = () => {
     setName('');
+    setAttribution('');
     setEmailValues({ email: '' });
   };
 
@@ -81,6 +85,7 @@ const RequestDemoCallToAction = ({ onSuccess, location, scmTool, setScmTool }) =
       name,
       email: emailValues.email,
       scmTool,
+      attribution,
       subToNewsletter,
       honeypotText,
       netlifyFormName,
@@ -114,7 +119,7 @@ const RequestDemoCallToAction = ({ onSuccess, location, scmTool, setScmTool }) =
     >
       <div className="mb-10">
         <TextField
-          label="Full name"
+          label="Full name*"
           type="text"
           name="name"
           id="request-demo-name-input"
@@ -124,29 +129,47 @@ const RequestDemoCallToAction = ({ onSuccess, location, scmTool, setScmTool }) =
         />
       </div>
 
+      <div className="lg:flex mb-10">
+        <div className="lg:w-1/2 mr-4">
+          <EmailField
+            label="Work email address*"
+            type="email"
+            name="email"
+            id="request-demo-email-input"
+            setValue={setEmailValues}
+            value={emailValues}
+            fullWidth
+          />
+        </div>
+
+        <div className="lg:w-1/2 mt-4 ml-4">
+          <ScmToolSelect
+            label="Primary source code host*"
+            onChange={setScmTool}
+            currentValue={scmTool}
+            idPrefix="request-demo-"
+            color="primary"
+          />
+        </div>
+      </div>
+
       <div className="mb-10">
-        <EmailField
-          label="Work email address"
-          type="email"
-          name="email"
-          id="request-demo-email-input"
-          setValue={setEmailValues}
-          value={emailValues}
+        <TextField
+          label="How did you hear about Roadie?"
+          type="text"
+          name="reported-attribution"
+          id="reported-attribution"
+          onChange={setAttribution}
+          value={attribution}
           fullWidth
         />
       </div>
 
-      <div className="mb-10">
-        <ScmToolSelect
-          label="Primary source code host"
-          onChange={setScmTool}
-          currentValue={scmTool}
-          idPrefix="request-demo-"
-          color="primary"
-        />
-      </div>
-
-      <SubscribeToNewsletterSwitch checked={subToNewsletter} onChange={setSubToNewsletter} className="mb-10" />
+      <SubscribeToNewsletterSwitch
+        checked={subToNewsletter}
+        onChange={setSubToNewsletter}
+        className="mb-10"
+      />
 
       <Recaptcha onChange={setRecaptchaResponse} setRecaptchaExpired={setRecaptchaExpired} />
 


### PR DESCRIPTION
## Motivation

We want to invest in activities that yield better leads. Yet, we have no way of knowing where the leads are coming from. The easiest thing to set up is self-reported attribution, allowing the person to explain where they heard of Roadie. 

Of course, this approach may have limitations, but's a solid way of knowing what kind of initiatives resonate the most in people's mind. The biggest advantage is that we don't have to set up any fancier multi-touch attribution.  

## Approach

I added a field to each form with a free text input. 

## TODO

- [ ] Add a field to salesforce (or choose a suitable one if it exists)
- [ ] Adjust zapier to send this additional field to Salesforce
- [ ] Try out the integration