### PR TITLE
Add a notion of api specs retrieved via broker

Fix documentation when running latest version of broker

### DIFF
--- a/content/docs/getting-started/openapi-specs/index.md
+++ b/content/docs/getting-started/openapi-specs/index.md
@@ -76,6 +76,16 @@ The `spec.definition.$openapi` property can point to a remote URL or it can be a
 
 _Note that if you are hosting your OpenAPI specs in GitHub and referencing them with the $openapi property, the link must point to the URL starting with `https://github.com` and not `https://raw.githubusercontent.com`._
 
+
+If you want to connect towards internal specs via [the broker connection](../../integrations/broker/index.md), you can use the protocol `broker://` to do that. For example:
+```
+spec:
+  definition:
+    $text: broker://<my-broker-token>/my-open-api-spec.json
+```
+    
+
+
 ### Step 2: Add the API to Backstage
 
 Once this YAML file is committed and available on GitHub, you can make Roadie Backstage aware of it using the catalog importer.

--- a/content/docs/integrations/broker/index.md
+++ b/content/docs/integrations/broker/index.md
@@ -82,12 +82,14 @@ The broker client is published as an npm package available to be downloaded, ins
 npm install --global snyk-broker
 BROKER_TOKEN=test \ 
 BROKER_SERVER_URL=https://<TENANT_NAME>.broker.roadie.so \
+PREFLIGHT_CHECKS_ENABLED=false \
 broker --disableBodyVarsSubstitution --disableHeaderVarsSubstitution
 ```
 
 ```bash
 BROKER_TOKEN=test \ 
 BROKER_SERVER_URL=https://<TENANT_NAME>.broker.roadie.so \
+PREFLIGHT_CHECKS_ENABLED=false \
 npx snyk-broker --disableBodyVarsSubstitution --disableHeaderVarsSubstitution
 ```
 
@@ -99,6 +101,7 @@ To provide the accept.json
 ACCEPT=accept.json
 BROKER_TOKEN=test \ 
 BROKER_SERVER_URL=https://<TENANT_NAME>.broker.roadie.so \
+PREFLIGHT_CHECKS_ENABLED=false \
 broker --disableBodyVarsSubstitution --disableHeaderVarsSubstitution
 ```
 


### PR DESCRIPTION
Add a notion of api specs retrieved via broker

Fix documentation when running latest version of broker