### PR TITLE
Add note about project support to our jenkins docs

### DIFF
--- a/content/docs/integrations/jenkins/index.md
+++ b/content/docs/integrations/jenkins/index.md
@@ -10,7 +10,9 @@ integrationType: OSS plugin
 
 ## Introduction
 
-The Jenkins plugin can display builds from and their statuses from your Jenkins instance.
+The Jenkins plugin can display build information from a GitHub Organization project in your Jenkins instances. 
+
+ℹ️ NB: Other Jenkins project types like Freestyle project and Pipeline are not supported yet.
 
 ![Jenkins Overview Content](./jenkins_overview.png)
 


### PR DESCRIPTION
This has tripped up costco and tavisca already I believe - they tried integrating not realising that Pipelines and Freestyle Projects were not supported.