### PR TITLE
Redirect to new url

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -123,4 +123,8 @@
   to = "/docs/scaffolder/writing-templates/"
   force = true
 
+[[redirects]]
+  from = "/docs/custom-plugins/connectivity/proxy/"
+  to = "/docs/custom-plugins/proxy/"
+  force = true
 


### PR DESCRIPTION
https://app.shortcut.com/larder/story/15956/marketting-site-search-is-broken