### PR TITLE
Adds a CTA to the Scaffolder doc

### DIFF
--- a/content/docs/scaffolder/writing-templates/index.md
+++ b/content/docs/scaffolder/writing-templates/index.md
@@ -15,10 +15,7 @@ A Scaffolder template is then run on demand by the users of Backstage to execute
 You can find a step by step guide to adding templates in Roadie [here](/docs/getting-started/scaffolding-components/)
 
 <div class="docs-cta">
-  <h4 class="docs-cta__title">See the Scaffolder in action</h4>
-  <p class="docs-cta__paragraph">
-    Discover more self-service possibilities by the hand of a Backstage expert. 
-  </p>
+  <h4 class="docs-cta__title">See the Backstage Scaffolder in action</h4>
   <a href="/request-demo/?utm_source=roadie-docs&utm_campaign=scaffolder-docs" target="_blank" class="docs-cta__button">
     Request a Roadie demo
   </a>

--- a/content/docs/scaffolder/writing-templates/index.md
+++ b/content/docs/scaffolder/writing-templates/index.md
@@ -15,7 +15,7 @@ A Scaffolder template is then run on demand by the users of Backstage to execute
 You can find a step by step guide to adding templates in Roadie [here](/docs/getting-started/scaffolding-components/)
 
 <div class="docs-cta">
-  <h4 class="docs-cta__title">Want to see the Scaffolder in action?</h4>
+  <h4 class="docs-cta__title">See the Scaffolder in action</h4>
   <p class="docs-cta__paragraph">
     Discover more self-service possibilities by the hand of a Backstage expert. 
   </p>

--- a/content/docs/scaffolder/writing-templates/index.md
+++ b/content/docs/scaffolder/writing-templates/index.md
@@ -14,6 +14,16 @@ A Scaffolder template is then run on demand by the users of Backstage to execute
 
 You can find a step by step guide to adding templates in Roadie [here](/docs/getting-started/scaffolding-components/)
 
+<div class="docs-cta">
+  <h4 class="docs-cta__title">Want to see the Scaffolder in action?</h4>
+  <p class="docs-cta__paragraph">
+    Discover more self-service possibilities by the hand of a Backstage expert. 
+  </p>
+  <a href="/request-demo/?utm_source=roadie-docs&utm_campaign=scaffolder-docs" target="_blank" class="docs-cta__button">
+    Request a Roadie demo
+  </a>
+</div>
+
 ## Components of a Template
 
 A Scaffolder template is a configurable process that will run one or more Scaffolder `steps`. The template will be run when a user visits the "Create Component" page in Backstage. `https://<tenant-name>.roadie.so/create`.

--- a/src/stylesheets/tailwind.css
+++ b/src/stylesheets/tailwind.css
@@ -62,14 +62,14 @@ html {
 
 .docs-cta {
   background-color: #fff1e8;
-  @apply px-4;
-  @apply py-6;
+  @apply p-6;
   @apply rounded-sm;
 }
 
 .docs-cta__title {
   margin-top: 0;
   @apply text-lg;
+  @apply mb-4;
 }
 
 .docs-cta__button {

--- a/src/stylesheets/tailwind.css
+++ b/src/stylesheets/tailwind.css
@@ -59,3 +59,27 @@ html {
   @apply font-bold;
   @apply text-3xl;
 }
+
+.docs-cta {
+  background-color: #fff1e8;
+  @apply px-4;
+  @apply py-6;
+  @apply rounded-sm;
+}
+
+.docs-cta__title {
+  margin-top: 0;
+  @apply text-lg;
+}
+
+.docs-cta__button {
+  display: inline-block;
+  text-decoration: none;
+  @apply bg-orange-700;
+  @apply text-white;
+  @apply font-bold;
+  @apply py-3;
+  @apply px-3;
+  @apply rounded-md;
+
+}


### PR DESCRIPTION
## Motivation

The Writing Scaffolder Templates page drives traffic from Google Search to the website, but there's no CTA on it.

## Approach

I added an HTML and CSS prompt to the docs. The link includes UTM parameters so we can hopefully track if this page converts leads. 

## Preview
<img width="1509" alt="Screenshot 2023-08-25 at 11 27 23" src="https://github.com/RoadieHQ/marketing-site/assets/4451393/0392bbbb-94f0-4d15-a8c9-010988fbc689">

https://deploy-preview-1105--roadie.netlify.app/docs/scaffolder/writing-templates/