### PR TITLE
Add correctness tutorials

### DIFF
--- a/content/docs/docs-nav.yaml
+++ b/content/docs/docs-nav.yaml
@@ -94,8 +94,8 @@ nav:
           - Proxy: '/docs/custom-plugins/connectivity/proxy'
           - Broker: '/docs/custom-plugins/connectivity/broker'
       - Legacy Method:
-        - Configuration: '/docs/custom-plugins/legacy/configuring/'
-        - Publishing Plugins: '/docs/custom-plugins/legacy/artifactory/'
+          - Configuration: '/docs/custom-plugins/legacy/configuring/'
+          - Publishing Plugins: '/docs/custom-plugins/legacy/artifactory/'
   - Scaffolder:
       - Writing scaffolder templates: '/docs/scaffolder/writing-templates/'
       - Certified templates: '/docs/scaffolder/certified-templates/'
@@ -132,6 +132,12 @@ nav:
           - Track On-prem Sonarqube metrics: '/docs/tech-insights/track-sonarqube/'
           - Enforce branch protection: '/docs/tech-insights/enforce-branch-protection/'
           - Track CODEOWNERS adoption: '/docs/tech-insights/track-codeowners-usage/'
+      - Check for Catalog Correctness:
+          - Mandatory Backstage metadata: '/docs/tech-insights/tracking-catalog-correctness/mandatory-metadata/'
+          - GitHub Annotation is present: '/docs/tech-insights/tracking-catalog-correctness/github-annotation/'
+          - Valid type: '/docs/tech-insights/tracking-catalog-correctness/valid-type/'
+          - Valid lifcycle: '/docs/tech-insights/tracking-catalog-correctness/valid-lifecycle/'
+          - Correct labels: '/docs/tech-insights/tracking-catalog-correctness/correct-labels/'
   - Catalog:
       - Managing locations: '/docs/catalog/location-management/'
       - Rich team pages: '/docs/catalog/rich-team-pages/'

--- a/content/docs/tech-insights/checks/index.md
+++ b/content/docs/tech-insights/checks/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Introduction to Checks
 publishedDate: '2022-11-15'
 description: Managing Checks.
 ---

--- a/content/docs/tech-insights/data-sources/index.md
+++ b/content/docs/tech-insights/data-sources/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Introduction to Data Sources
 publishedDate: '2022-11-15'
 description: Managing Data Sources.
 ---

--- a/content/docs/tech-insights/introduction/index.md
+++ b/content/docs/tech-insights/introduction/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Introduction to Tech Insights
 publishedDate: '2022-11-15'
 description: An introduction about Tech Insights plugin.
 ---

--- a/content/docs/tech-insights/scorecards/index.md
+++ b/content/docs/tech-insights/scorecards/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Introduction to Scorecards
 publishedDate: '2022-11-15'
 description: Managing Scorecards.
 ---

--- a/content/docs/tech-insights/tracking-catalog-correctness/correct-labels/index.md
+++ b/content/docs/tech-insights/tracking-catalog-correctness/correct-labels/index.md
@@ -1,0 +1,65 @@
+---
+title: Check labels are being used correctly
+publishedDate: '2022-10-06'
+description: Managing Scorecards.
+---
+
+Backstage allows adding “labels” to entities in the Catalog. Some teams use labels as a way to specify the “tier” of a service, amongst other use cases.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: service-1
+  labels:
+    tier: 3
+spec:
+  type: service
+  owner: sample-team
+  lifecycle: production
+```
+
+There are typically two problems with using labels in Backstage.
+
+1. Not all teams will add the `tier` label to their components.
+2. Teams will make up their own labels, and duplicate labels will frequently emerge.
+
+We suggest people using our Tech Insights functionality to create checks to help teams manage labels.
+
+## Enforcing mandatory labels
+
+You can use Tech Insights to find components which do not meet the minimum requirements for labels.
+
+Imagine you wanted `tier` and `region` to be mandatory. To get a list of components wihch have not added the `tier` label, you would create a check with the following attributes:
+
+| Field | Input |
+| --- | --- |
+| Name | Mandatory Backstage labels |
+| Description | Adding these labels will help other people in the company understand how to find and interact with your component. |
+| Data source | Entity Metadata (this is built-in). |
+| Fact | Label keys (this returns a list of all of the label keys on an entity) |
+| Fact operator | Contains |
+| Value | tier,region |
+
+With this check in place, we can now get a list of all services which have not added the `tier` and `region` labels.
+
+Here’s a video showing how to construct this check:
+
+https://www.loom.com/share/7c60ba8a6e924868982e9faf96f1a6a4
+
+## Enforcing allowable (but optional) labels
+
+In order to find duplicate labels, the best practice is to establish and maintain a list of allowed labels. For example, you may wish to allow the labels `tier` and `region`, but not the label `location`.
+
+To get a list of components wihch have added unallowed label, you would create a check with the following attributes:
+
+| Field | Input |
+| --- | --- |
+| Name | Allowed Backstage labels |
+| Description |  |
+| Data source | Entity Metadata (this is built-in). |
+| Fact | Label keys (this returns a list of all of the label keys on an entity) |
+| Fact operator | Contains |
+| Value | tier,region |
+
+To change the list of allowable labels, simple edit the check and add to the Value field.

--- a/content/docs/tech-insights/tracking-catalog-correctness/correct-labels/index.md
+++ b/content/docs/tech-insights/tracking-catalog-correctness/correct-labels/index.md
@@ -26,7 +26,7 @@ There are typically two problems with using labels in Backstage.
 
 We suggest people using our Tech Insights functionality to create checks to help teams manage labels.
 
-## Enforcing mandatory labels
+### Enforcing mandatory labels
 
 You can use Tech Insights to find components which do not meet the minimum requirements for labels.
 
@@ -47,7 +47,7 @@ Here’s a video showing how to construct this check:
 
 https://www.loom.com/share/7c60ba8a6e924868982e9faf96f1a6a4
 
-## Enforcing allowable (but optional) labels
+### Enforcing allowable (but optional) labels
 
 In order to find duplicate labels, the best practice is to establish and maintain a list of allowed labels. For example, you may wish to allow the labels `tier` and `region`, but not the label `location`.
 

--- a/content/docs/tech-insights/tracking-catalog-correctness/github-annotation/index.md
+++ b/content/docs/tech-insights/tracking-catalog-correctness/github-annotation/index.md
@@ -1,0 +1,31 @@
+---
+title: Check the GitHub annotation is set 
+publishedDate: '2022-10-06'
+description: Managing Scorecards.
+---
+
+The GitHub annotation powers more functionalities in Backstage than any other. Frequently, the GitHub project slug is used to load data related to the associated entity.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: marketing-site
+  annotations:
+    github.com/project-slug: RoadieHQ/marketing-site
+```
+
+Backstage works best when the GitHub project-slug annotation is set on as many components as possible.
+
+To create a check to ensure that the annotation is set, use the following attributes:
+
+| Field | Input |
+| --- | --- |
+| Name | GitHub annotation must be set on Backstage Component metadata |
+| Description | Setting the component metadata will allow many Backstage GitHub plugins and features to work |
+| Data source | Entity Metadata (built-in). |
+| Fact | Annotation keys (this returns a list of all of the annotation keys on an entity) |
+| Fact operator | Contains |
+| Value | github.com/project-slug |
+
+Once this check completes its first run, you should see data come in showing the Backstage entities which need improvement.

--- a/content/docs/tech-insights/tracking-catalog-correctness/mandatory-metadata/index.md
+++ b/content/docs/tech-insights/tracking-catalog-correctness/mandatory-metadata/index.md
@@ -1,0 +1,19 @@
+---
+title: Check mandatory Backstage metadata is set
+publishedDate: '2022-10-06'
+description: Managing Scorecards.
+---
+
+Entity metadata such, as the title and description, is pretty much necessary to make the Backstage Catalog useful. You can use Tech Insights to find components which are not fully filled out.
+
+For example, you can create a check with the following attributes to find services which are missing the title metadata:
+
+| Field | Input |
+| --- | --- |
+| Name | Ensure titles are present on Backstage entities. |
+| Description | A title is a human readable name for the Backstage component. |
+| Data source | Entity Metadata (built-in). |
+| Fact | Has Title |
+| Fact operator | Is True |
+
+Roadie provides other metadata values to check for, such as the description, tags, lifecycle, namespace, and owner. 

--- a/content/docs/tech-insights/tracking-catalog-correctness/valid-lifecycle/index.md
+++ b/content/docs/tech-insights/tracking-catalog-correctness/valid-lifecycle/index.md
@@ -1,0 +1,20 @@
+---
+title: Check Component lifecycle is valid
+publishedDate: '2022-10-06'
+description: Managing Scorecards.
+---
+
+The `spec.lifecycle` of a component can be a useful indicator of the maturity of a component. However, it is an arbitrary string in the Backstage spec, and the catalog can get confusing when people enter arbitrary values.
+
+You can enforce a small number of valid values with the following check:
+
+| Field | Input |
+| --- | --- |
+| Name | Backstage component metadata lifecycle should be valid |
+| Description | Only a small number of lifecycles are supported. |
+| Data source | Entity Metadata (this is built-in). |
+| Fact | Lifecycle |
+| Fact operator | Is One Of |
+| Value | production,deprecated,experimental |
+
+Make sure to adapt the Value field according to the lifecycles you want to support.

--- a/content/docs/tech-insights/tracking-catalog-correctness/valid-type/index.md
+++ b/content/docs/tech-insights/tracking-catalog-correctness/valid-type/index.md
@@ -1,0 +1,20 @@
+---
+title: Check Component type is valid
+publishedDate: '2022-10-06'
+description: Managing Scorecards.
+---
+
+In Backstage, the `spec.type` is important to the build up your [system model](https://roadie.io/blog/modelling-software-backstage/) in the Catalog. However, `spec.type` can accept arbitrary strings. You can use Tech Insights to ensure all your components are following your desired schema.
+
+Create a check with the following attributes:
+
+| Field | Input |
+| --- | --- |
+| Name | Backstage Component type must be valid. |
+| Description | Only a small number of Component types are valid. service, website, library |
+| Data source | Entity Metadata (this is built-in). |
+| Fact | Type |
+| Fact operator | Is One Of |
+| Value | library,website,service,documentation |
+
+Make sure to adapt the Value field according to the types you want to support.


### PR DESCRIPTION
I added them as a subsection in the Tech Insights nav as it'd saturate the Recipes section which has a different kind of guide. 