### PR TITLE
Add links to syk docs to explain annotation values

### DIFF
--- a/content/docs/tech-insights/builtin-data-sources/index.md
+++ b/content/docs/tech-insights/builtin-data-sources/index.md
@@ -234,7 +234,7 @@ Generates fact data about Snyk projects configured for the entity.
   * `github.com/project-slug`, to identify the target based on its GitHub repository name
   * `snyk.io/exclude-project-ids`, to exclude specific projects you might not want.
 
-The data source follows the same annotation structure as the official Snyk Backstage plugin. It is possible to use multiple different annotations. At a minimum one of `targets`, `target-id`, `project-ids` or GitHub project slug is needed.
+The data source follows the same annotation structure as the official [Snyk Backstage plugin](https://github.com/snyk-tech-services/backstage-plugin-snyk#getting-started). It is possible to use multiple different annotations. At a minimum one of `targets`, `target-id`, `project-ids` or GitHub project slug is needed. Read more about these concepts [here](https://docs.snyk.io/snyk-admin/introduction-to-snyk-projects).
 
 
 #### Authentication


### PR DESCRIPTION
We use the same annotations as the snyk plugin in our data source but these refer to Snyk concepts which the user may not be familiar with so link to docs which explain what the values are and how to get them.