### PR TITLE
Add z-index to movile nav

### DIFF
--- a/src/components/SitewideHeader/DocsDrawerMenu.js
+++ b/src/components/SitewideHeader/DocsDrawerMenu.js
@@ -21,7 +21,7 @@ const DrawerMenu = ({ location }) => (
     leaveFrom="opacity-100 scale-100"
     leaveTo="opacity-0 scale-95"
   >
-    <Popover.Panel focus className="absolute top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden">
+    <Popover.Panel focus className="absolute top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden z-20">
       <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 bg-white divide-y-2 divide-gray-50">
         <div className="pt-5 pb-6 px-5">
           <DrawerMenuHeader />

--- a/src/components/SitewideHeader/DrawerMenu.js
+++ b/src/components/SitewideHeader/DrawerMenu.js
@@ -67,7 +67,7 @@ const DrawerMenu = () => (
     leaveFrom="opacity-100 scale-100"
     leaveTo="opacity-0 scale-95"
   >
-    <Popover.Panel focus className="absolute top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden">
+    <Popover.Panel focus className="absolute top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden z-20">
       <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 bg-white divide-y-2 divide-gray-50">
         <div className="pt-5 pb-6 px-5">
 


### PR DESCRIPTION
## Before

The sitewide nav is open but it's hidden behind the title of an article.

![Screenshot 2024-03-26 at 20 27 20](https://github.com/RoadieHQ/marketing-site/assets/562403/572fa434-a120-4251-883e-625b8b28550d)

## After

![Screenshot 2024-03-26 at 20 27 28](https://github.com/RoadieHQ/marketing-site/assets/562403/6b2d59e1-1c6f-4d63-9403-62eabcb2da2a)
