### PR TITLE
Add some horiz padding to blog posts

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -93,12 +93,12 @@ const BlogPostTemplate = ({ data }) => {
         </header>
 
         <section
-          className="prose prose-primary max-w-none max-w-lg mx-auto lg:max-w-3xl mb-24"
+          className="prose prose-primary max-w-none max-w-lg mx-auto lg:max-w-3xl mb-24 p-2"
           dangerouslySetInnerHTML={{ __html: post.html }}
         />
       </article>
 
-      <div className="relative max-w-lg mx-auto lg:max-w-xl mb-10">
+      <div className="relative max-w-lg mx-auto lg:max-w-xl mb-10 p-2">
         <SubscribeToNewsletterCTA setModalOpen={setModalOpen} email={email} setEmail={setEmail} />
       </div>
 


### PR DESCRIPTION


## Before

Text is wedged against the sides of the screen on mobile

![Screenshot 2024-03-26 at 20 32 54](https://github.com/RoadieHQ/marketing-site/assets/562403/8bb6f133-8b6f-4786-b701-afdf6311dd0f)

## After

Text has some space

![Screenshot 2024-03-26 at 20 33 02](https://github.com/RoadieHQ/marketing-site/assets/562403/ae6c10e9-9eb1-4365-900b-f0e2267f57f6)
