### PR TITLE
Add repo annotations to examples

### DIFF
--- a/content/docs/getting-started/adding-a-catalog-item/azure-devops/index.md
+++ b/content/docs/getting-started/adding-a-catalog-item/azure-devops/index.md
@@ -15,6 +15,9 @@ examples:
       metadata:
         name: artist-web
         description: The place to be, for great artists
+      annotations:
+        dev.azure.com/project-repo: roadie-demo/artist-web
+        backstage.io/techdocs-ref: dir:.
       spec:
         type: website
         lifecycle: production
@@ -44,6 +47,9 @@ examples:
       metadata:
         name: artist-api
         description: Retrieve artist details
+      annotations:
+        dev.azure.com/project-repo: roadie-demo/artist-api
+        backstage.io/techdocs-ref: dir:.
       spec:
         type: openapi
         lifecycle: production

--- a/content/docs/getting-started/adding-a-catalog-item/bitbucket/index.md
+++ b/content/docs/getting-started/adding-a-catalog-item/bitbucket/index.md
@@ -16,6 +16,9 @@ examples:
       metadata:
         name: artist-web
         description: The place to be, for great artists
+      annotations:
+        bitbucket.com/project-slug: roadie-demo/artist-web
+        backstage.io/techdocs-ref: dir:.
       spec:
         type: website
         lifecycle: production
@@ -45,6 +48,9 @@ examples:
       metadata:
         name: artist-api
         description: Retrieve artist details
+      annotations:
+        bitbucket.com/project-slug: roadie-demo/artist-api
+        backstage.io/techdocs-ref: dir:.
       spec:
         type: openapi
         lifecycle: production

--- a/content/docs/getting-started/adding-a-catalog-item/github/index.md
+++ b/content/docs/getting-started/adding-a-catalog-item/github/index.md
@@ -15,6 +15,9 @@ examples:
       metadata:
         name: artist-web
         description: The place to be, for great artists
+      annotations:
+        github.com/project-slug: roadie-demo/artist-web
+        backstage.io/techdocs-ref: dir:. 
       spec:
         type: website
         lifecycle: production
@@ -44,6 +47,9 @@ examples:
       metadata:
         name: artist-api
         description: Retrieve artist details
+      annotations:
+        github.com/project-slug: roadie-demo/artist-api
+        backstage.io/techdocs-ref: dir:. 
       spec:
         type: openapi
         lifecycle: production

--- a/content/docs/getting-started/adding-a-catalog-item/gitlab/index.md
+++ b/content/docs/getting-started/adding-a-catalog-item/gitlab/index.md
@@ -15,6 +15,9 @@ examples:
       metadata:
         name: artist-web
         description: The place to be, for great artists
+      annotations:
+        gitlab.com/project-slug: roadie-demo/artist-web
+        backstage.io/techdocs-ref: dir:.
       spec:
         type: website
         lifecycle: production
@@ -44,6 +47,9 @@ examples:
       metadata:
         name: artist-api
         description: Retrieve artist details
+      annotations:
+        gitlab.com/project-slug: roadie-demo/artist-api
+        backstage.io/techdocs-ref: dir:.
       spec:
         type: openapi
         lifecycle: production


### PR DESCRIPTION
Added examples of the `annotations.{scm_url}/project-slug:` to the Component and API examples for GitHub, Bitbucket, Gitlab, and Azure DevOps.