### PR TITLE
Update callback url for GHES oauth

### DIFF
--- a/content/docs/integrations/ghe/index.md
+++ b/content/docs/integrations/ghe/index.md
@@ -32,7 +32,7 @@ Roadie integrates with both cloud and self-hosted GitHub installations. This gui
 1. Create a new OAuth app within GitHub Enterprise Server developer settings
    * You can find the possibility to do that the URL `https://<your-server-instance>/settings/applications/new`.
 2. For `Homepage URL` set a value like `https://<your-roadie-tenant>.roadie.so`
-3. For `Authorization callback URL` set a value like `https://<your-roadie-tenant>.roadie.so/api/auth/ghes/handler/frame`
+3. For `Authorization callback URL` set a value like `https://<your-roadie-tenant>.roadie.so/api/auth/github/handler/frame`
 4. When the app has been created, generate a new secret for it by clicking `Generate a new client secret` button
 
 ![ghes-oauth-app.png](ghes-oauth-app.png)


### PR DESCRIPTION
We've decided to just configure the github auth provider with GHES creds for now rather than having a separate provider. This is until we can update the plugins to use the "multiplexed" scmauth provider.