### PR TITLE
Update plugin creation page

### DIFF
--- a/content/docs/custom-plugins/getting-started/index.md
+++ b/content/docs/custom-plugins/getting-started/index.md
@@ -62,7 +62,7 @@ When we have navigated the available files and are happy with how they look, we 
 
 First we need to install needed dependencies. We will run `npm i` from the root of the monorepo. This may take some time depending on your internet connection.
 
-After needed dependencies are installed we can spin up a development server in watch mode `npm run develop:watch --workspace=docs-plugin`
+After needed dependencies are installed we can spin up a development server in watch mode `npm run develop:watch --workspace=<your-plugin-name>`
 
 ![monorepo_developing.gif](monorepo_developing.gif)
 


### PR DESCRIPTION
Clarify watch command to execute, to make clear it's a placeholder.
as it is, the command looks literal, leading to an error:

```
➜  roadie-tribe-squads-list git:(main) ✗ npm run develop:watch --workspace=docs-plugin
npm error No workspaces found:
npm error   --workspace=docs-plugin
npm error A complete log of this run can be found in: /Users/adrianmorenopena/.npm/_logs/2024-11-08T20_59_29_884Z-debug-0.log
```