### PR TITLE
Correctly set host in branch deploys

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,7 +43,12 @@ const getContentfulHost = () => {
 
 const getSiteUrl = () => {
   const netlifySiteName = get(process.env, 'SITE_NAME');
+  // There's a good chance that this CONTEXT variable is the only thing we should be switching
+  // on in this function as it's a more specific variable than the SITE_NAME.
+  // Docs: https://docs.netlify.com/configure-builds/environment-variables/
+  const context = get(process.env, 'CONTEXT');
   if (netlifySiteName === 'roadie-preview') return 'https://preview.roadie.io';
+  if (context === 'branch-deploy') return get(process.env, 'DEPLOY_PRIME_URL');
   return 'https://roadie.io';
 };
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,15 +47,21 @@ const getSiteUrl = () => {
   // on in this function as it's a more specific variable than the SITE_NAME.
   // Docs: https://docs.netlify.com/configure-builds/environment-variables/
   const context = get(process.env, 'CONTEXT');
+  const pullRequest = get(process.env, 'PULL_REQUEST');
+  console.log('BUILD_ENV_VARS');
+  console.log('CONTEXT', context);
+  console.log('SITE_NAME', netlifySiteName);
+  console.log('DEPLOY_PRIME_URL', get(process.env, 'DEPLOY_PRIME_URL'));
+  console.log('PULL_REQUEST', pullRequest, typeof pullRequest);
   if (netlifySiteName === 'roadie-preview') return 'https://preview.roadie.io';
-  if (context === 'branch-deploy') return get(process.env, 'DEPLOY_PRIME_URL');
+  if (context === 'deploy-preview') return get(process.env, 'DEPLOY_PRIME_URL');
   return 'https://roadie.io';
 };
 
 const shouldCrawl = () => {
   const ctx = get(process.env, 'CONTEXT');
   const netlifySiteName = get(process.env, 'SITE_NAME');
-  return (netlifySiteName === 'roadie') && (ctx !== 'deploy-preview');
+  return netlifySiteName === 'roadie' && ctx !== 'deploy-preview';
 };
 
 const getContentfulOptions = () => {


### PR DESCRIPTION
The robot.txt on branch deploys has the host wrong ([here's an example](https://deploy-preview-1420--roadie.netlify.app/robots.txt)).

```txt
User-agent: *
Disallow: /
Sitemap: https://roadie.io/sitemap-index.xml
Host: https://roadie.io
```

This PR changes it to (for example):

```txt
User-agent: *
Disallow: /
Sitemap: https://deploy-preview-1420--roadie.netlify.app/sitemap-index.xml
Host: https://deploy-preview-1420--roadie.netlify.app/
```