### PR TITLE
Correcting URL for action list

### DIFF
--- a/content/docs/scaffolder/writing-templates/index.md
+++ b/content/docs/scaffolder/writing-templates/index.md
@@ -187,7 +187,7 @@ ${{ user.entity.spec.profile.email }}
 
 You can find all the available actions to your Roadie instance by visiting the following page from within Roadie:
 
-`https://<tenant-name>.roadie.so/templates/actions`
+`https://<tenant-name>.roadie.so/create/actions`
 
 
 ### Conditional Steps


### PR DESCRIPTION
Fixing the URL from /templates/actions to /create/actions