### PR TITLE
Permissions docs changes

### DIFF
--- a/content/docs/details/managing-policies/index.md
+++ b/content/docs/details/managing-policies/index.md
@@ -1,5 +1,5 @@
 ---
-title: Policies Management
+title: Managing Policies
 publishedDate: '2024-11-05T21:00:00.0Z'
 description: How to configure and manage policies in Roadie for access control.
 ---
@@ -12,9 +12,9 @@ In Roadie, **policies** are integral components of the permissions framework, go
 
 **Key aspects of policies:**
 
-- **Authorization Decisions:** Policies determine whether a user is permitted to execute a particular action. For instance, a policy might allow only the owner of a service to delete it from the catalog. For more on policy definitions, refer to the [Backstage documentation](https://backstage.io/docs/permissions/writing-a-policy/).
-- **Conditional Logic:** Policies can incorporate complex conditions, such as verifying if a user belongs to a specific group or possesses certain attributes, to make nuanced authorization decisions. Details are available in the [Backstage documentation on custom rules](https://backstage.io/docs/permissions/custom-rules/).
-- **Customization:** Administrators have the flexibility to craft custom policies tailored to their organization's unique requirements, ensuring that access controls align with internal processes and security standards. Read more in the [Backstage custom rules documentation](https://backstage.io/docs/permissions/custom-rules/).
+- **Authorization Decisions:** Policies determine whether a user is permitted to execute a particular action. For instance, a policy might allow only the owner of a service to delete it from the catalog. 
+- **Conditional Logic:** Policies can incorporate complex conditions, such as verifying if a user belongs to a specific group or possesses certain attributes, to make nuanced authorization decisions. 
+- **Customization:** Administrators have the flexibility to craft custom policies tailored to their organization's unique requirements, ensuring that access controls align with internal processes and security standards. 
 
 By implementing policies, Roadie ensures that access to resources is managed effectively, enhancing security and maintaining the integrity of the development environment.
 

--- a/content/docs/details/managing-roles/index.md
+++ b/content/docs/details/managing-roles/index.md
@@ -1,0 +1,56 @@
+---
+title: Managing Roles
+publishedDate: '2024-06-14T21:00:00.0Z'
+description: How to configure roles using permissions.
+---
+
+## Introduction
+
+Roadie comes with RBAC out of the box. We provide 4 default roles: `admin`, `viewer`, `maintainer` and `tech-insights-admin`. It is possible to also define custom roles - please contact our sales team if this is something you are interested in.
+
+| Name                | Description                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| admin               | Can perform any action in Roadie                                                                                               |
+| viewer              | Can only view data within Roadie                                                                                               |
+| maintainer          | Can read and write data, but cannot access administration settings or tech insights editing                                    |
+| tech-insights-admin | Can edit scorecards, checks and data sources in tech insights. This role requires one of viewer / maintainer to work correctly |
+
+## Assigning Roles
+
+There are two ways to assign a role to a user in Roadie:
+
+- Assign roles in the user management screen
+- Provide a `roles` field in your id token provided to Roadie during login.
+
+### User Management
+
+- Visit the user management section in `https://<tenant name>.roadie.so/administration/settings/manage-users`.
+- Find the name of the user you would like to assign a role to.
+- Click the edit pencil and then add the roles you would like to assign the user.
+
+### Roles from Identity providers id token
+
+If your Roadie tenant is using a custom identity provider, you can choose to include the roles field in your id token as follows:
+
+```json
+{
+  "sub": "77d0c4cb-706c-4aa4-b18e-bed538a33aa7",
+  "roles": ["viewer", "tech-insights-admin"]
+}
+```
+
+## Setting the default roles
+
+If a user has no role associated yet, e.g. if it is the first time they have logged in and there are no roles associated with the user, then the user is allowed the policies associated with the default roles. There can be many default roles.
+
+To edit the default roles:
+
+- Visit `http://<tenant name>.roadie.so/administration/settings/roles`
+- Click the edit pencil beside the roles you would like to be the default roles
+- The click "Set as default role" and save.
+- You can perform similar steps to make a role no longer a default role.
+
+## Creating custom roles
+**This feature is a paid add-on of the Role-Based Access Control feature. If you want access, please contact our support or sales teams.**
+
+Users with the permissions required to set new or custom roles can do so using the User Management area in the Adminstration section. New roles are composed of policies. To understand how to set custom policies, please review the [Managing Policies](/docs/details/managing-policies/) section.

--- a/content/docs/details/permissions/index.md
+++ b/content/docs/details/permissions/index.md
@@ -6,46 +6,31 @@ description: How to configure access control permissions in Roadie.
 
 ## Introduction
 
-Roadie comes with RBAC out of the box. We provide 4 default roles: `admin`, `viewer`, `maintainer` and `tech-insights-admin`. It is possible to also define custom roles - please contact our sales team if this is something you are interested in.
+Roadie permissions allow rules to be set about which users have acces to which features and information.
 
-| Name                | Description                                                                                                                    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| admin               | Can perform any action in Roadie                                                                                               |
-| viewer              | Can only view data within Roadie                                                                                               |
-| maintainer          | Can read and write data, but cannot access administration settings or tech insights editing                                    |
-| tech-insights-admin | Can edit scorecards, checks and data sources in tech insights. This role requires one of viewer / maintainer to work correctly |
+This can be set at a coarse level (i.e. whole features of the application) or at a fine-grain level (i.e. the ability to view specific entities within the catalog).
 
-## Assigning Roles
+A good example of a permission is the ability to allow users to see a Scaffolder Template. Let's say this Template has the ability to change a cloud budget for a given service. Not everyone within an organisation may have that ability. A permissions attached to that Template would allow the team governing Roadie to limit access to that Template. 
 
-There are two ways to assign a role to a user in Roadie:
+## Features
 
-- Assign roles in the user management screen
-- Provide a `roles` field in your id token provided to Roadie during login.
+- **User Management** user roles can be managed via the no-code Roadie Admin UI or ingested from an Identity Provider via the identity token.
+- **Custom Roles** can be created to manage subsets of users
+- **Custom Policies** can be created to cater for specific permissions
+- **Custom Permissions** can be created and consumed in Custom Policies (from a custom plugin for example)
 
-### User Management
+## Structure
 
-- Visit the user management section in `https://<tenant name>.roadie.so/administration/settings/manage-users`.
-- Find the name of the user you would like to assign a role to.
-- Click the edit pencil and then add the roles you would like to assign the user.
+Roadie permissions are made up:
 
-### Roles from Identity providers id token
+- **Users**: users have Roles which grant them permissions to execute certain tasks within Roadie or view certain information
+- **Roles**: which are attached to users. They are groups of policies. 
+- **Policies**: which are groups of permissions, rolled up into Roles. 
+- **Permissions**: granular code-level gates that evaluate whether an individual users has access to a given piece of functionality.
 
-If your Roadie tenant is using a custom identity provider, you can choose to include the roles field in your id token as follows:
+## Backstage Permissions Framework
 
-```json
-{
-  "sub": "77d0c4cb-706c-4aa4-b18e-bed538a33aa7",
-  "roles": ["viewer", "tech-insights-admin"]
-}
-```
+Roadies Permissions system is based on the Bacsktage Permissions framework. More information on the framework in general can be found in Backstage docs:
 
-## Setting the default roles
-
-If a user has no role associated yet, e.g. if it is the first time they have logged in and there are no roles associated with the user, then the user is allowed the policies associated with the default roles. There can be many default roles.
-
-To edit the default roles:
-
-- Visit `http://<tenant name>.roadie.so/administration/settings/roles`
-- Click the edit pencil beside the roles you would like to be the default roles
-- The click "Set as default role" and save.
-- You can perform similar steps to make a role no longer a default role.
+- Backstage docs on [policy definitions](https://backstage.io/docs/permissions/writing-a-policy/).
+- Backstage docs on [custom rules](https://backstage.io/docs/permissions/custom-rules/).

--- a/content/docs/details/permissions/index.md
+++ b/content/docs/details/permissions/index.md
@@ -6,11 +6,11 @@ description: How to configure access control permissions in Roadie.
 
 ## Introduction
 
-Roadie permissions allow rules to be set about which users have acces to which features and information.
+Role-based access control in Roadie allows rules to be set about which users have access to which features and information.
 
 This can be set at a coarse level (i.e. whole features of the application) or at a fine-grain level (i.e. the ability to view specific entities within the catalog).
 
-A good example of a permission is the ability to allow users to see a Scaffolder Template. Let's say this Template has the ability to change a cloud budget for a given service. Not everyone within an organisation may have that ability. A permissions attached to that Template would allow the team governing Roadie to limit access to that Template. 
+A good example of a permission is the ability to allow users to see a Scaffolder template. Let's say this template has the ability to change a cloud budget for a given service. Not everyone within an organisation may have that ability. A permissions attached to that Template would allow the team governing Roadie to limit access to that template. 
 
 ## Features
 
@@ -21,7 +21,7 @@ A good example of a permission is the ability to allow users to see a Scaffolder
 
 ## Structure
 
-Roadie permissions are made up:
+Role-based access control in Roadie is made up:
 
 - **Users**: users have Roles which grant them permissions to execute certain tasks within Roadie or view certain information
 - **Roles**: which are attached to users. They are groups of policies. 
@@ -30,7 +30,7 @@ Roadie permissions are made up:
 
 ## Backstage Permissions Framework
 
-Roadies Permissions system is based on the Bacsktage Permissions framework. More information on the framework in general can be found in Backstage docs:
+Roadies role-based access control system is inspired by the Bacsktage Permissions framework. More information on that framework in general can be found in Backstage docs but is not necessary to understand when interacting with Roadie:
 
 - Backstage docs on [policy definitions](https://backstage.io/docs/permissions/writing-a-policy/).
 - Backstage docs on [custom rules](https://backstage.io/docs/permissions/custom-rules/).

--- a/content/docs/docs-nav.yaml
+++ b/content/docs/docs-nav.yaml
@@ -90,7 +90,10 @@ nav:
           - Accessing public resources: '/docs/details/backend-reading-allow-list/'
           - Allowlisting Roadie traffic: '/docs/details/allowlisting-roadie-traffic/'
           - How Roadie connects: '/docs/details/how-roadie-connects/'
-      - Permissions: '/docs/details/permissions/'
+      - Permissions: 
+        - Introduction: '/docs/details/permissions/'
+        - Roles: '/docs/details/managing-roles/'
+        - Policies: '/docs/details/managing-policies/'
       - Proxy Creation: '/docs/details/create-proxy/'
       - Setting secrets: '/docs/details/setting-secrets/'
       - TechDocs:
@@ -102,8 +105,6 @@ nav:
           - Required metadata: '/docs/details/required-metadata/'
           - Requesting plugins: '/docs/details/requesting-plugins/'
       - Setting secrets: '/docs/details/setting-secrets/'
-      - Permissions:
-          - Managing Policies: '/docs/details/managing-policies/'
       - Updating the UI: '/docs/details/updating-the-ui/'
   - Custom plugins:
       - Overview: '/docs/custom-plugins/overview'


### PR DESCRIPTION
Tweak permissions docs structure to make it cleaner. Move Backstage referenced docs out into a separate section

https://app.shortcut.com/larder/story/23840/policy-docs-snags