### PR TITLE
Remove references to mermaid backend techdocs plugin

### DIFF
--- a/content/docs/details/techdocs/index.md
+++ b/content/docs/details/techdocs/index.md
@@ -41,7 +41,6 @@ We currently include the following MkDocs plugins in our build process:
 - [mkdocs-schema-reader](https://pypi.org/project/mkdocs-schema-reader/) - converts JSON Schema files into markdown
 - [mkdocs-minify-plugin](https://github.com/byrnereese/mkdocs-minify-plugin) - minifies HTML, JS or CSS files
 - [mkdocs-glightbox](https://github.com/blueswen/mkdocs-glightbox) - displays images, iframes, inline content and videos
-- [markdown-inline-mermaid](https://github.com/mermaid-js/mermaid) - generates diagrams from markdown-like text.
 - [mkdocs-kroki-plugin](https://github.com/AVATEAM-IT-SYSTEMHAUS/mkdocs-kroki-plugin) - A diagram library supporting multiple different diagram formats. See https://kroki.io/ for more information.
 - [mkdocs-print-site-plugin](https://timvink.github.io/mkdocs-print-site-plugin/index.html) - Allows you to render a whole doc with all pages so that you can export it to PDF or HTML via the browser.
 
@@ -55,7 +54,7 @@ plugins:
   - techdocs-core
   - glightbox 
 markdown_extensions:
-  - markdown_inline_mermaid
+  - attr_list
 ```
 
 Note that the [`techdocs-core`](https://github.com/backstage/mkdocs-techdocs-core?tab=readme-ov-file#mkdocs-plugins-and-extensions) plugin packages many of the above plugins already.
@@ -128,22 +127,14 @@ NB: This plugin currently requires each page to have an H1 header - [see current
 
 ### Using Mermaid Diagrams
 
-Roadie supports two ways of displaying Mermaid diagrams via tech docs. The first way is to use Mermaid JS on build time via an extension which must first be enabled in your `mkdocs.yaml`:
+Roadie supports displaying Mermaid diagrams via tech docs. The diagrams work by default using a Javascript based Mermaid renderer [`mermaid`](https://www.npmjs.com/package/mermaid) 
 
-```yaml
-markdown_extensions:
-  - markdown_inline_mermaid
-```
-
-The second way is to render mermaid diagrams on runtime by using a TechDocs addon. This does not need modifications to the `mkdocs.yaml` by default, but the build time extension _should not_ be present for the runtime rendering to take place.
-
-
-Then you can add mermaid diagrams as follows:
+You can add mermaid diagrams as follows:
 ````
 ```mermaid
 %%{init: {'theme': 'forest'}}%%
 graph LR
-  A[Start] --> B{Error?};
+  A[Start] --> B{Error?};R
   B -->|Yes| C[Hmm...];
   C --> D[Debug];
   D --> B;


### PR DESCRIPTION
Prefer frontend rendered mermaid diagrams which seem to be more robust. 