### PR TITLE
Document scopes need to create repo in scaffolder

### DIFF
--- a/content/docs/scaffolder/writing-templates/index.md
+++ b/content/docs/scaffolder/writing-templates/index.md
@@ -293,6 +293,7 @@ parameters:
             secretsKey: USER_OAUTH_TOKEN
             additionalScopes:
               github:
+              # - admin:org # Needed if you want to create a repo
                 - workflow
           allowedHosts:
             - github.com


### PR DESCRIPTION
If using a user OAuth token the correct scopes must be requested to perform certain actions. In particular, admin:org is needed to create repos. This isn't particularly obvious and is a common use case so I've put it here.