### PR TITLE
Remove rbac rollout messaging

### DIFF
--- a/content/docs/details/custom-plugins/index.md
+++ b/content/docs/details/custom-plugins/index.md
@@ -6,7 +6,7 @@ description: How to configure and manage permissions and policies for use in Cus
 
 ## Introduction
 
-**This feature is currently in the process of being rolled out. If you want access, please contact our support or sales teams.**
+**This feature is part of a paid add-on. If you want access, please contact our support or sales teams.**
 
 You can choose to make use of custom permissions in Roadie as part of a custom plugin. This tutorial assumes you have already created and published a [custom plugin](/docs/custom-plugins/overview/).
 

--- a/content/docs/details/managing-policies/index.md
+++ b/content/docs/details/managing-policies/index.md
@@ -6,7 +6,7 @@ description: How to configure and manage policies in Roadie for access control.
 
 ## Introduction
 
-**This feature is currently in the process of being rolled out. If you want access, please contact our support or sales teams.**
+**This feature is part of a paid add-on. If you want access, please contact our support or sales teams.**
 
 In Roadie, **policies** are integral components of the permissions framework, governing access control within the platform. They define the rules and conditions under which users can perform specific actions on various resources, such as services, components, or documentation.
 


### PR DESCRIPTION
RBAC GA clean-up: we used to say 'feature is in the process of rolling out' on some docs. This PR removes that.