### PR TITLE
Apply correct url for managing roles and policies

### DIFF
--- a/content/docs/details/managing-policies/index.md
+++ b/content/docs/details/managing-policies/index.md
@@ -12,13 +12,13 @@ In Roadie, **policies** are integral components of the permissions framework, go
 
 **Key aspects of policies:**
 
-- **Authorization Decisions:** Policies determine whether a user is permitted to execute a particular action. For instance, a policy might allow only the owner of a service to delete it from the catalog. 
-- **Conditional Logic:** Policies can incorporate complex conditions, such as verifying if a user belongs to a specific group or possesses certain attributes, to make nuanced authorization decisions. 
-- **Customization:** Administrators have the flexibility to craft custom policies tailored to their organization's unique requirements, ensuring that access controls align with internal processes and security standards. 
+- **Authorization Decisions:** Policies determine whether a user is permitted to execute a particular action. For instance, a policy might allow only the owner of a service to delete it from the catalog.
+- **Conditional Logic:** Policies can incorporate complex conditions, such as verifying if a user belongs to a specific group or possesses certain attributes, to make nuanced authorization decisions.
+- **Customization:** Administrators have the flexibility to craft custom policies tailored to their organization's unique requirements, ensuring that access controls align with internal processes and security standards.
 
 By implementing policies, Roadie ensures that access to resources is managed effectively, enhancing security and maintaining the integrity of the development environment.
 
-To configure this in Roadie we provide a UI for **Policies Management** and you can access it at: `https://<tenant name>.roadie.so/administration/settings/policies`.
+To configure this in Roadie we provide a UI for **Policies Management** and you can access it at: `https://<tenant name>.roadie.so/administration/manage-users/policies`.
 
 Currently, a set of permissions is available from the upstream Backstage project, with the option to create and validate new permissions.
 

--- a/content/docs/details/managing-roles/index.md
+++ b/content/docs/details/managing-roles/index.md
@@ -47,12 +47,13 @@ If a user has no role associated yet, e.g. if it is the first time they have log
 
 To edit the default roles:
 
-- Visit `http://<tenant name>.roadie.so/administration/settings/roles`
+- Visit `http://<tenant name>.roadie.so/administration/manage-users/roles`
 - Click the edit pencil beside the roles you would like to be the default roles
 - The click "Set as default role" and save.
 - You can perform similar steps to make a role no longer a default role.
 
 ## Creating custom roles
+
 **This feature is a paid add-on of the Role-Based Access Control feature. If you want access, please contact our support or sales teams.**
 
 Users with the permissions required to set new or custom roles can do so using the User Management area in the Adminstration section. New roles are composed of policies. To understand how to set custom policies, please review the [Managing Policies](/docs/details/managing-policies/) section.


### PR DESCRIPTION
We moved this section outside Settings so use correct url in documentation