### PR TITLE
docs: add beta disclaimer to Catalog Completeness section

### DIFF
--- a/content/docs/catalog/repositories/index.md
+++ b/content/docs/catalog/repositories/index.md
@@ -9,6 +9,13 @@ description: How repositories are modelled and ingested into the catalog
 Repositories are modelled in the Roadie Backstage catalog using the Repository Kind.
 
 ### Catalog Completeness
+<div role="alert">
+  <div class="docs-cta__warning_title">Beta Feature</div>
+  <div  class="docs-cta__warning_message">
+    <p>The Catalog Completeness feature is currently in beta. Please reach out to Roadie Support to request this is enabled.
+    </p>
+  </div>
+</div>
 Repositories allow us to effectively measure the completeness of your catalog - that is, whether all the software in your organisation is represented by entities in the catalog.
 
 Once your Repositories are added, Admins will be able to see a graph of catalog completeness in the Administration section of Roadie. 


### PR DESCRIPTION
Context: https://roadiehq.slack.com/archives/C079G7FNMGS/p1752838012462289?thread_ts=1752836264.932169&cid=C079G7FNMGS

Adds a clearly styled disclaimer to indicate that the "Catalog Completeness" feature is currently in beta and requires a request to support.
