### PR TITLE
Remove Relativity logo from CustomerLogoCloud component

### DIFF
--- a/src/components/landing/CustomerLogoCloud.js
+++ b/src/components/landing/CustomerLogoCloud.js
@@ -18,21 +18,11 @@ import NetlifyLogoPng from '../../../content/assets/home/customer-logos/netlify-
 import BaillieGiffordLogoPng from '../../../content/assets/home/customer-logos/baillie-gifford-monochrome-standardized.png';
 import AstraZenecaLogoPng from '../../../content/assets/home/customer-logos/astrazenca-monochrome-standardized.png';
 import SumUpLogoPng from '../../../content/assets/home/customer-logos/sumup-monochrome-standardized.png';
-import RelativityLogoPng from '../../../content/assets/home/customer-logos/relativity-monochrome-standardized.png';
 import BaillieGiffordLogo from '../../../content/assets/home/customer-logos/baillie-gifford-monochrome-standardized.webp';
 import AstraZenecaLogo from '../../../content/assets/home/customer-logos/astrazenca-monochrome-standardized.webp';
 import SumUpLogo from '../../../content/assets/home/customer-logos/sumup-monochrome-standardized.webp';
-import RelativityLogo from '../../../content/assets/home/customer-logos/relativity-monochrome-standardized.webp';
 
 export const LOGOS = [
-  {
-    src: {
-      png: RelativityLogoPng,
-      webp: RelativityLogo,
-    },
-    alt: 'Relativity logo',
-  },
-
   {
     src: {
       png: SumUpLogoPng,


### PR DESCRIPTION
- Remove import statements for Relativity logo assets
- Remove Relativity logo object from LOGOS array
- Reduces logo count from 10 to 9

Context: https://roadiehq.slack.com/archives/C07HU5GDKU1/p1753785035745999 