### PR TITLE
Don't filter newsletter entries out of /blog/

### DIFF
--- a/src/gatsby/rssFeedPlugin.mjs
+++ b/src/gatsby/rssFeedPlugin.mjs
@@ -20,7 +20,6 @@ const blogFeed = {
     query AllBlogPostsForRss {
       blogs: allContentfulBlogPost(
         sort: {date: DESC}
-        filter: {tags: {ne: "newsletter"}}
       ) {
         edges {
           node {

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -39,7 +39,7 @@ export default BlogIndex;
 
 export const pageQuery = graphql`
   query BlogIndex {
-    allContentfulBlogPost(sort: { date: DESC }, filter: { tags: { ne: "newsletter" } }) {
+    allContentfulBlogPost(sort: { date: DESC }) {
       edges {
         node {
           description {

--- a/src/queries/gatsbyNodeQueries.mjs
+++ b/src/queries/gatsbyNodeQueries.mjs
@@ -1,6 +1,6 @@
 export const BLOGS_QUERY = `
 {
-  blogs: allContentfulBlogPost(sort: {date: DESC}, filter: { tags: { ne: "newsletter" }}) {
+  blogs: allContentfulBlogPost(sort: {date: DESC}) {
     edges {
       node {
         slug


### PR DESCRIPTION
This is cleanup after #1626 was merged

Newsletter issues (Backstage Weekly) have been deleted from the list of blog posts on contentful, so there is no-longer a need to filter them out when building the site.

The test that this works, is basically just that Backstage Weekly newsletter issues don't show up on [this page](https://deploy-preview-1627--roadie.netlify.app/blog/) even though we're no-longer explicitly filtering them out.