### PR TITLE
Use splats in Backstage Weekly redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -275,12 +275,12 @@
 # This handles 2 special cases where we published a Backstage Weekly issue inder the slug:
 #   "blog/roadies-backstage-weekly-[N]-[rest of slug]"
 [[redirects]]
-  from = "/blog/roadies-backstge-weekly-*"
-  to = "/backstage-weekly/:splat:"
+  from = "/blog/roadies-backstage-weekly-*"
+  to = "/backstage-weekly/:splat"
   force = true
 
 # This handles all other Backstage Weekly redirects.
 [[redirects]]
-  from = "/blog/backstge-weekly-*"
+  from = "/blog/backstage-weekly-*"
   to = "/backstage-weekly/:splat"
   force = true


### PR DESCRIPTION
No functional changes. Just a cleaner way of writing about 95 redirects.

https://app.shortcut.com/larder/story/29383/migrate-backstage-weekly-to-dedicated-content-model

## Tests:

```
curl -sS -D - https://deploy-preview-1628--roadie.netlify.app/blog/roadies-backstage-weekly-50-new-backstage-users-unconference-active-page-in -o /dev/null
HTTP/2 301
age: 0
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; fwd=miss
content-type: text/plain; charset=utf-8
date: Mon, 13 Oct 2025 13:06:26 GMT
location: /backstage-weekly/50-new-backstage-users-unconference-active-page-in
```

```
» curl -sS -D - https://deploy-preview-1628--roadie.netlify.app/blog/backstage-weekly-36-backstage-unconference -o /dev/null
HTTP/2 301
age: 1
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; fwd=miss
content-type: text/plain; charset=utf-8
date: Mon, 13 Oct 2025 13:05:32 GMT
location: /backstage-weekly/36-backstage-unconference
```

```
» curl -sS -D - https://deploy-preview-1628--roadie.netlify.app/blog/backstage-weekly-36-backstage-unconference/ -o /dev/null
HTTP/2 301
age: 0
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; fwd=miss
content-type: text/plain
date: Mon, 13 Oct 2025 13:05:25 GMT
location: /backstage-weekly/36-backstage-unconference/
```