### PR TITLE
Fix persistent slash in docs search input

### DIFF
--- a/src/components/AlgoliaAutocomplete/AlgoliaAutocomplete.js
+++ b/src/components/AlgoliaAutocomplete/AlgoliaAutocomplete.js
@@ -53,6 +53,7 @@ const AlgoliaAutocomplete = ({ as = 'div', className, ...rest }) => {
 
   const openSearchOnHotkeyPress = useCallback((event) => {
     if (event.key === '/') {
+      event.preventDefault();
       search.setIsOpen(true);
       search.refresh();
     }


### PR DESCRIPTION
To see the issue: [visit this page](https://roadie.io/docs/) and press `/`. There's a `/` char in the search box.
To see the fix: [do the same thing here](https://deploy-preview-1631--roadie.netlify.app/docs/)