### PR TITLE
Disable sort select instead of hiding

### DIFF
--- a/src/components/forms/Select.js
+++ b/src/components/forms/Select.js
@@ -21,12 +21,12 @@ const Select = ({
   const { accent, border, background, text } = INPUT_COLORS[color];
   const btnClass = classnames(
     'w-full rounded-md shadow-sm py-3 px-4 text-left border',
-    background,
-    text,
-    accent,
-    border,
     {
-      'opacity-50 cursor-not-allowed': disabled,
+      [background]: !disabled,
+      [text]: !disabled,
+      [accent]: !disabled,
+      [border]: !disabled,
+      'opacity-50 bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed': disabled,
     }
   );
 
@@ -52,14 +52,23 @@ const Select = ({
 
           {!open && (
             <button
-              className="absolute inset-y-0 right-0 flex items-center pr-3"
+              className={classnames(
+                'absolute inset-y-0 right-0 flex items-center pr-3',
+                {
+                  'cursor-not-allowed': disabled,
+                }
+              )}
               onClick={openSelect}
               aria-label="Open select input"
               tabIndex={-1}
               type="button"
               disabled={disabled}
             >
-              <ChevronDownIcon className="h-5 w-5" />
+              <ChevronDownIcon
+                className={classnames('h-5 w-5', {
+                  'text-gray-400': disabled,
+                })}
+              />
             </button>
           )}
 

--- a/src/pages/backstage/plugins.js
+++ b/src/pages/backstage/plugins.js
@@ -135,12 +135,14 @@ const BackstagePlugins = ({ data, location }) => {
               </div>
 
               <Field
-                className={classnames('text-right w-full flex items-center justify-end', {
-                  visible: npmDataLoadingState === 'loaded',
-                  invisible: npmDataLoadingState !== 'loaded',
-                })}
+                className="text-right w-full flex items-center justify-end"
+                disabled={npmDataLoadingState !== 'loaded'}
               >
-                <Label className="mr-2 whitespace-nowrap">
+                <Label
+                  className={classnames('mr-2 whitespace-nowrap', {
+                    'text-gray-400': npmDataLoadingState !== 'loaded',
+                  })}
+                >
                   Sort by:
                 </Label>
 
@@ -151,7 +153,7 @@ const BackstagePlugins = ({ data, location }) => {
                     options={SORT_ORDERS}
                     name="sort-order"
                     optionKey="label"
-                    disabled={npmDataLoadingState === 'error'}
+                    disabled={npmDataLoadingState !== 'loaded'}
                   />
                 </div>
               </Field>


### PR DESCRIPTION
## Before

[Live demo](https://roadie.io/backstage/plugins/)

The sort select would be hidden until the npm data is loaded

<img width="531" height="196" alt="Screenshot 2025-10-25 at 00 50 43" src="https://github.com/user-attachments/assets/4158b721-d70f-45ac-9862-37dd7eb3a301" />

## After

[Live demo](https://deploy-preview-1650--roadie.netlify.app/backstage/plugins/)

The sort select is disabled until the npm data is loaded. This keeps the page layout more consistant during data loading.

<img width="416" height="190" alt="Screenshot 2025-10-25 at 00 49 48" src="https://github.com/user-attachments/assets/33c63d6b-00f6-44f1-9d8f-341951b7c387" />